### PR TITLE
Fix event page contact and FAB behaviour

### DIFF
--- a/_includes/event-sections.html
+++ b/_includes/event-sections.html
@@ -2,12 +2,52 @@
 <div class="divider" aria-hidden="true"></div>
 
 <article class="content">
+  {% assign about_copy = page.about | default: nil %}
+  {% if about_copy or content %}
   <section id="details" aria-labelledby="about">
     <h3 id="about" class="section-title">About the Event</h3>
     <div class="prose">
-      {{ content }}
+      {% if about_copy %}
+        {{ about_copy | markdownify }}
+      {% endif %}
+      {% if content %}
+        {{ content }}
+      {% endif %}
     </div>
   </section>
+  {% endif %}
+
+  {% if page.what_makes_it_different %}
+  <div class="divider" aria-hidden="true"></div>
+  <section id="what-makes-it-different" aria-labelledby="what-makes-title">
+    <h3 id="what-makes-title" class="section-title">What makes it different?</h3>
+    <div class="prose">{{ page.what_makes_it_different | markdownify }}</div>
+  </section>
+  {% endif %}
+
+  {% if page.how_it_works %}
+  <div class="divider" aria-hidden="true"></div>
+  <section id="how-it-works" aria-labelledby="how-it-works-title">
+    <h3 id="how-it-works-title" class="section-title">How it works</h3>
+    <div class="prose">{{ page.how_it_works | markdownify }}</div>
+  </section>
+  {% endif %}
+
+  {% if page.why_join %}
+  <div class="divider" aria-hidden="true"></div>
+  <section id="why-join" aria-labelledby="why-join-title">
+    <h3 id="why-join-title" class="section-title">Why join?</h3>
+    <div class="prose">{{ page.why_join | markdownify }}</div>
+  </section>
+  {% endif %}
+
+  {% if page.closing %}
+  <div class="divider" aria-hidden="true"></div>
+  <section id="closing" aria-labelledby="closing-title">
+    <h3 id="closing-title" class="section-title">Closing note</h3>
+    <div class="prose">{{ page.closing | markdownify }}</div>
+  </section>
+  {% endif %}
 
   {% if page.about_video %}
   <div class="divider" aria-hidden="true"></div>

--- a/_includes/event-sections.html
+++ b/_includes/event-sections.html
@@ -1,8 +1,7 @@
-<!-- Divider before the first section -->
-<div class="divider" aria-hidden="true"></div>
-
 <article class="content">
   {% assign about_copy = page.about | default: nil %}
+  {% assign has_sections = false %}
+
   {% if about_copy or content %}
   <section id="details" aria-labelledby="about">
     <h3 id="about" class="section-title">About the Event</h3>
@@ -15,52 +14,55 @@
       {% endif %}
     </div>
   </section>
+  {% assign has_sections = true %}
   {% endif %}
 
   {% if page.what_makes_it_different %}
-  <div class="divider" aria-hidden="true"></div>
+  {% if has_sections %}<div class="divider section-divider" aria-hidden="true"></div>{% endif %}
   <section id="what-makes-it-different" aria-labelledby="what-makes-title">
     <h3 id="what-makes-title" class="section-title">What makes it different?</h3>
     <div class="prose">{{ page.what_makes_it_different | markdownify }}</div>
   </section>
+  {% assign has_sections = true %}
   {% endif %}
 
   {% if page.how_it_works %}
-  <div class="divider" aria-hidden="true"></div>
+  {% if has_sections %}<div class="divider section-divider" aria-hidden="true"></div>{% endif %}
   <section id="how-it-works" aria-labelledby="how-it-works-title">
     <h3 id="how-it-works-title" class="section-title">How it works</h3>
     <div class="prose">{{ page.how_it_works | markdownify }}</div>
   </section>
+  {% assign has_sections = true %}
   {% endif %}
 
   {% if page.why_join %}
-  <div class="divider" aria-hidden="true"></div>
+  {% if has_sections %}<div class="divider section-divider" aria-hidden="true"></div>{% endif %}
   <section id="why-join" aria-labelledby="why-join-title">
     <h3 id="why-join-title" class="section-title">Why join?</h3>
     <div class="prose">{{ page.why_join | markdownify }}</div>
   </section>
+  {% assign has_sections = true %}
   {% endif %}
 
   {% if page.closing %}
-  <div class="divider" aria-hidden="true"></div>
-  <section id="closing" aria-labelledby="closing-title">
-    <h3 id="closing-title" class="section-title">Closing note</h3>
-    <div class="prose">{{ page.closing | markdownify }}</div>
-  </section>
+  {% if has_sections %}<div class="divider section-divider" aria-hidden="true"></div>{% endif %}
+  <div class="prose closing-note">{{ page.closing | markdownify }}</div>
+  {% assign has_sections = true %}
   {% endif %}
 
   {% if page.about_video %}
-  <div class="divider" aria-hidden="true"></div>
+  {% if has_sections %}<div class="divider section-divider" aria-hidden="true"></div>{% endif %}
   <section id="about-video" aria-labelledby="about-nom">
     <h3 id="about-nom" class="section-title">About {{ page.title }}</h3>
     <div class="video-portrait" data-embed="{{ page.about_video | escape }}">
       <iframe loading="lazy" title="About {{ page.title }} (portrait)" src="{{ page.about_video | escape }}"></iframe>
     </div>
   </section>
+  {% assign has_sections = true %}
   {% endif %}
 
   {% if page.recap_videos and page.recap_videos.size > 0 %}
-  <div class="divider-left" aria-hidden="true"></div>
+  <div class="divider section-divider divider-left" aria-hidden="true"></div>
   <section id="recaps" aria-labelledby="recaps-title">
     <h3 id="recaps-title" class="section-title">Event recaps</h3>
     <p class="contact-sub" style="margin:0 0 18px; text-align:left;">CATCH THE VIBE OF THE EVENT WITH THESE VIDEOS</p>

--- a/_includes/event-sections.html
+++ b/_includes/event-sections.html
@@ -62,7 +62,7 @@
   {% endif %}
 
   {% if page.recap_videos and page.recap_videos.size > 0 %}
-  <div class="divider section-divider divider-left" aria-hidden="true"></div>
+  <div class="divider section-divider" aria-hidden="true"></div>
   <section id="recaps" aria-labelledby="recaps-title">
     <h3 id="recaps-title" class="section-title">Event recaps</h3>
     <p class="contact-sub" style="margin:0 0 18px; text-align:left;">CATCH THE VIBE OF THE EVENT WITH THESE VIDEOS</p>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -116,15 +116,6 @@ content="
   .divider{width:100%;height:1px;margin:28px 0 18px;background:linear-gradient(90deg,rgba(255,255,255,.06),rgba(255,255,255,.02));box-shadow:0 1px 0 rgba(255,255,255,.02) inset;border-radius:1px;backdrop-filter:blur(2px);-webkit-backdrop-filter:blur(2px)}
   @media (max-width:768px){.divider{margin:10px 0 16px}}
 
-  /* Better mobile tap behavior for the phone link */
-#phone-link {
-  -webkit-tap-highlight-color: transparent;
-  touch-action: manipulation;
-}
-
-  .title{text-align:center;margin-bottom:18px}
-  .title h2{color:var(--accent);margin:0;font-size:1.9rem;font-weight:700;letter-spacing:.2px}
-
   .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);border:0}
 
   .cards-row{display:flex;flex-wrap:wrap;gap:22px;justify-content:center;align-items:flex-start}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -246,32 +246,7 @@ content="
   .gallery-skeletons .gal-skel:not(:first-child){ display: none; }
 
   /* ===== Contact ===== */
-  .contact-wrap{max-width:1200px;margin:0 auto;padding:0 12px;}
-  .contact-head{display:flex;align-items:center;gap:12px;margin-bottom:18px;justify-content:center;}
-  .contact-head .logo-lg{width:44px;height:44px;border-radius:10px;object-fit:cover;}
-  .contact-sub{margin:0;font-weight:700;letter-spacing:.6px;color:var(--muted);}
-  .contact-list{list-style:none;margin:0;padding:0;display:grid;gap:16px;}
-  .row{display:grid;grid-template-columns:28px 1fr;column-gap:12px;align-items:center;}
-  .icon{width:28px;height:28px;color:var(--accent);}
-  .link{color:var(--text-main);text-decoration:none;font-weight:700;}
-  .link:hover{color:var(--accent);}
-  .email-text{overflow-wrap:anywhere;word-break:break-word;line-break:anywhere;}
-  .phone-wrap{position:relative;}
-  .phone-menu{
-    position:absolute;top:100%;left:40px;margin-top:6px;
-    background:var(--card);border-radius:10px;box-shadow:0 8px 24px rgba(0,0,0,.4);
-    padding:8px;display:flex;gap:8px;z-index:5;
-  }
-  .phone-menu[hidden]{display:none;}
-  .phone-menu a{display:inline-block;padding:8px 12px;border-radius:8px;text-decoration:none;font-weight:700;background:rgba(255,255,255,.06);color:var(--text-main) !important;}
-  .phone-menu a:hover{background:rgba(255,255,255,.12);color:var(--accent) !important;}
-  @media (min-width:1100px){
-    .contact-list{display:flex;justify-content:center;flex-wrap:wrap;gap:24px 32px;}
-    .row{display:flex;gap:12px;}
-  }
-  @media (prefers-color-scheme: light){
-    .phone-menu{box-shadow:0 8px 24px rgba(0,0,0,.12);}
-  }
+  {% include styles/contact.css %}
 </style>
 
 <!-- Light divider tweak -->

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -62,6 +62,7 @@ content="
   :root {
     --bg:#181818; --card:#212121; --muted:#d0d0d0; --accent:#fce029; --datebox:#303030; --text-main:#fff;
     --topbar-height-desktop:58px; --topbar-height-mobile:48px;
+    --topbar-chrome-bg:rgba(24,24,24,.82); --topbar-chrome-border:rgba(255,255,255,.18);
     --animated-height-desktop:150px; --animated-height-mobile:80px;
     --line-height-desktop:1.4; --line-height-mobile:1.5;
     --animated-font-size-max:1.6rem;
@@ -69,9 +70,9 @@ content="
   html,body{margin:0;height:100%}
   body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
 
-  .topbar-bleed{position:fixed;top:0;left:0;right:0;height:env(safe-area-inset-top,0px);background:rgba(24,24,24,.07);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);z-index:10002;pointer-events:none}
+  .topbar-bleed{position:fixed;top:0;left:0;right:0;height:env(safe-area-inset-top,0px);background:var(--topbar-chrome-bg);border-bottom:1px solid var(--topbar-chrome-border);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px);z-index:10002;pointer-events:none}
 
-  .topbar{position:fixed;top:0;left:0;right:0;display:flex;align-items:center;padding-left:24px;padding-top:env(safe-area-inset-top,0px);height:calc(var(--topbar-height-desktop) + env(safe-area-inset-top,0px));box-sizing:border-box;z-index:10003;border-bottom:1px solid rgba(255,255,255,.3);background:rgba(24,24,24,.07);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px)}
+  .topbar{position:fixed;top:0;left:0;right:0;display:flex;align-items:center;padding-left:24px;padding-top:env(safe-area-inset-top,0px);height:calc(var(--topbar-height-desktop) + env(safe-area-inset-top,0px));box-sizing:border-box;z-index:10003;box-shadow:0 1px 0 var(--topbar-chrome-border);background:var(--topbar-chrome-bg);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px)}
   .topbar-left{display:flex;align-items:center;height:100%}
   .logo{height:36px;width:36px;border-radius:8px;margin-right:12px;object-fit:cover}
   .brand{font-size:1.45rem;font-weight:700;letter-spacing:.5px;color:#fff}
@@ -80,13 +81,7 @@ content="
   @media (max-width:600px){.topbar-spacer{height:calc(var(--topbar-height-mobile) + env(safe-area-inset-top,0px))}}
 
   @media (prefers-color-scheme: light){
-    .topbar,
-    .topbar-bleed{
-      background: rgba(255,255,255,.55) !important;
-      border-bottom: 1px solid rgba(0,0,0,.08);
-      -webkit-backdrop-filter: saturate(180%) blur(14px);
-      backdrop-filter: saturate(180%) blur(14px);
-    }
+    :root{--topbar-chrome-bg:rgba(255,255,255,.7);--topbar-chrome-border:rgba(0,0,0,.08)}
   }
   
   .topbar-left.home-link { color: inherit; text-decoration: none; }

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -62,7 +62,6 @@ content="
   :root {
     --bg:#181818; --card:#212121; --muted:#d0d0d0; --accent:#fce029; --datebox:#303030; --text-main:#fff;
     --topbar-height-desktop:58px; --topbar-height-mobile:48px;
-    --topbar-chrome-bg:rgba(24,24,24,.82); --topbar-chrome-border:rgba(255,255,255,.18);
     --animated-height-desktop:150px; --animated-height-mobile:80px;
     --line-height-desktop:1.4; --line-height-mobile:1.5;
     --animated-font-size-max:1.6rem;
@@ -70,9 +69,9 @@ content="
   html,body{margin:0;height:100%}
   body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
 
-  .topbar-bleed{position:fixed;top:0;left:0;right:0;height:env(safe-area-inset-top,0px);background:var(--topbar-chrome-bg);border-bottom:1px solid var(--topbar-chrome-border);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px);z-index:10002;pointer-events:none}
+  .topbar-bleed{position:fixed;top:0;left:0;right:0;height:env(safe-area-inset-top,0px);background:rgba(24,24,24,.07);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);z-index:10002;pointer-events:none}
 
-  .topbar{position:fixed;top:0;left:0;right:0;display:flex;align-items:center;padding-left:24px;padding-top:env(safe-area-inset-top,0px);height:calc(var(--topbar-height-desktop) + env(safe-area-inset-top,0px));box-sizing:border-box;z-index:10003;box-shadow:0 1px 0 var(--topbar-chrome-border);background:var(--topbar-chrome-bg);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px)}
+  .topbar{position:fixed;top:0;left:0;right:0;display:flex;align-items:center;padding-left:24px;padding-top:env(safe-area-inset-top,0px);height:calc(var(--topbar-height-desktop) + env(safe-area-inset-top,0px));box-sizing:border-box;z-index:10003;border-bottom:1px solid rgba(255,255,255,.3);background:rgba(24,24,24,.07);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px)}
   .topbar-left{display:flex;align-items:center;height:100%}
   .logo{height:36px;width:36px;border-radius:8px;margin-right:12px;object-fit:cover}
   .brand{font-size:1.45rem;font-weight:700;letter-spacing:.5px;color:#fff}
@@ -81,7 +80,13 @@ content="
   @media (max-width:600px){.topbar-spacer{height:calc(var(--topbar-height-mobile) + env(safe-area-inset-top,0px))}}
 
   @media (prefers-color-scheme: light){
-    :root{--topbar-chrome-bg:rgba(255,255,255,.7);--topbar-chrome-border:rgba(0,0,0,.08)}
+    .topbar,
+    .topbar-bleed{
+      background: rgba(255,255,255,.55) !important;
+      border-bottom: 1px solid rgba(0,0,0,.08);
+      -webkit-backdrop-filter: saturate(180%) blur(14px);
+      backdrop-filter: saturate(180%) blur(14px);
+    }
   }
   
   .topbar-left.home-link { color: inherit; text-decoration: none; }

--- a/_includes/microbar.html
+++ b/_includes/microbar.html
@@ -1,16 +1,17 @@
 <!-- Mobile microbar (JS fills; hidden on desktop via CSS) -->
 <div class="mobile-info-bar" id="mobileInfoBar" aria-hidden="true">
   <div class="mobile-info-inner">
-    <div class="microbar-left">
-      <span class="micro-title" id="microTitle"></span>
-      <span class="micro-meta-line"><span id="microLeft1"></span></span>
-      <span class="micro-meta-line"><span id="microLeft2"></span></span>
-      <span class="micro-meta-line"><span id="microLeft3"></span></span>
+    <span class="micro-title" id="microTitle"></span>
+    <div class="micro-line" id="microLine1">
+      <span class="micro-meta" id="microLeft1"></span>
+      <a class="micro-action" id="microAction1" target="_blank" rel="noopener" hidden></a>
     </div>
-    <div class="microbar-right">
-      <a class="microbar-link" id="microRight1" target="_blank" rel="noopener"></a>
-      <a class="microbar-link" id="microRight2" target="_blank" rel="noopener"></a>
-      <span class="microbar-link" id="microRight3"></span>
+    <div class="micro-line" id="microLine2">
+      <span class="micro-meta" id="microLeft2"></span>
+      <a class="micro-action" id="microAction2" target="_blank" rel="noopener" hidden></a>
+    </div>
+    <div class="micro-line" id="microLine3">
+      <span class="micro-meta" id="microLeft3"></span>
     </div>
   </div>
 </div>

--- a/_includes/scripts-event-core.html
+++ b/_includes/scripts-event-core.html
@@ -198,12 +198,8 @@
     }
 
     if (M.L3){
-      const detailBits = [dDiff, dGroup, dPrice].filter(Boolean);
-      M.L3.textContent = detailBits.join(' · ');
-      if (M.line3){
-        if (M.L3.textContent){ M.line3.removeAttribute('hidden'); }
-        else { M.line3.setAttribute('hidden',''); }
-      }
+      M.L3.textContent = '';
+      M.line3?.setAttribute('hidden','');
     }
   } else {
     if (M.line1){ M.line1.removeAttribute('hidden'); }

--- a/_includes/scripts-event-core.html
+++ b/_includes/scripts-event-core.html
@@ -86,12 +86,14 @@
   const M = {
     bar: document.getElementById('mobileInfoBar'),
     title: document.getElementById('microTitle'),
+    line1: document.getElementById('microLine1'),
+    line2: document.getElementById('microLine2'),
+    line3: document.getElementById('microLine3'),
     L1: document.getElementById('microLeft1'),
     L2: document.getElementById('microLeft2'),
     L3: document.getElementById('microLeft3'),
-    R1: document.getElementById('microRight1'),
-    R2: document.getElementById('microRight2'),
-    R3: document.getElementById('microRight3'),
+    A1: document.getElementById('microAction1'),
+    A2: document.getElementById('microAction2'),
   };
 
   let scheduled = false, base = null, timeStr = '', locText = '', locLink = '', ticket = '';
@@ -101,15 +103,27 @@
   const dDiff = "{{ page.highlights.difficulty | default: 'Beginner-friendly' | escape }}";
   const dPrice = "{{ page.highlights.price | default: '₹ 350/-' | escape }}";
 
-  function updateShareOffset(){
-    if (!shareFab) return;
-    let bottom = 12;
-    if (fabBook && !fabBook.hasAttribute('hidden')){
-      const height = fabBook.getBoundingClientRect().height || fabBook.offsetHeight || 0;
-      if (!height){ requestAnimationFrame(updateShareOffset); return; }
-      bottom += Math.round(height + 8);
+  function updateFabSpacing(){
+    const docEl = document.documentElement;
+    const bookVisible = fabBook && !fabBook.hasAttribute('hidden');
+    let bookHeight = 0;
+    if (bookVisible){
+      const rect = fabBook.getBoundingClientRect();
+      bookHeight = rect.height || fabBook.offsetHeight || 0;
+      if (!bookHeight){ requestAnimationFrame(updateFabSpacing); return; }
     }
-    document.documentElement.style.setProperty('--fab-share-bottom', bottom + 'px');
+
+    let shareBottom = 12;
+    if (shareFab){
+      if (bookVisible){ shareBottom += Math.round(bookHeight + 8); }
+      docEl.style.setProperty('--fab-share-bottom', shareBottom + 'px');
+    }
+
+    let pad = 16;
+    if (bookVisible && window.innerWidth < 960){
+      pad = Math.max(22, Math.round(bookHeight + 22));
+    }
+    docEl.style.setProperty('--mobile-bottom-pad', pad + 'px');
   }
 
   if (match){
@@ -139,43 +153,75 @@
       if (fabBook){
         fabBook.href = ticket;
         fabBook.removeAttribute('hidden');
-        requestAnimationFrame(updateShareOffset);
-      } else {
-        updateShareOffset();
       }
-      document.documentElement.style.setProperty('--mobile-bottom-pad', '96px');
+      requestAnimationFrame(updateFabSpacing);
     } else {
       if (fabBook){ fabBook.setAttribute('hidden', ''); }
-      document.documentElement.style.setProperty('--mobile-bottom-pad', '16px');
-      updateShareOffset();
+      updateFabSpacing();
     }
   } else {
     // Not scheduled
     scHeading && scHeading.setAttribute('hidden','');
     if (scBlock) scBlock.hidden = true;
     if (fabBook){ fabBook.setAttribute('hidden',''); }
-    document.documentElement.style.setProperty('--mobile-bottom-pad', '16px');
-    updateShareOffset();
+    updateFabSpacing();
   }
 
   // Microbar content + visibility
   if (M.title) M.title.textContent = titleFallback;
   if (scheduled && base){
     const timePart = timeStr && timeStr.trim() ? ` | ${timeStr.trim()}` : '';
-    M.L1 && (M.L1.textContent = fmtDateOnly(base) + timePart);
-    M.L2 && (M.L2.textContent = locText || '');
-    M.L3 && (M.L3.textContent = '');
-    if (M.R1) { M.R1.textContent = 'Add to Calendar'; M.R1.href = makeICS({ title: titleFallback, start: base, durationHours: 3, locationText: locText, locationUrl: locLink, description: location.href }); M.R1.removeAttribute('hidden'); }
-    if (M.R2) { M.R2.textContent = 'Get Directions'; if (locLink) { M.R2.href = locLink; M.R2.removeAttribute('hidden'); } else { M.R2.setAttribute('hidden',''); } }
-    if (M.R3) M.R3.textContent = '';
+    if (M.L1){ M.L1.textContent = fmtDateOnly(base) + timePart; M.line1?.removeAttribute('hidden'); }
+    if (M.A1){
+      M.A1.textContent = 'Add to Calendar';
+      M.A1.href = makeICS({ title: titleFallback, start: base, durationHours: 3, locationText: locText, locationUrl: locLink, description: location.href });
+      M.A1.hidden = false;
+    }
+
+    if (M.L2){
+      M.L2.textContent = locText || '';
+      if (locText){
+        M.line2?.removeAttribute('hidden');
+      } else {
+        M.line2?.setAttribute('hidden','');
+      }
+    }
+    if (M.A2){
+      if (locLink){
+        M.A2.textContent = 'Get Directions';
+        M.A2.href = locLink;
+        M.A2.hidden = false;
+      } else {
+        M.A2.hidden = true;
+        M.A2.removeAttribute('href');
+      }
+    }
+
+    if (M.L3){
+      const detailBits = [dDiff, dGroup, dPrice].filter(Boolean);
+      M.L3.textContent = detailBits.join(' · ');
+      if (M.line3){
+        if (M.L3.textContent){ M.line3.removeAttribute('hidden'); }
+        else { M.line3.setAttribute('hidden',''); }
+      }
+    }
   } else {
-    // three-line left, three tokens right
-    M.L1 && (M.L1.textContent = '{{ page.title | escape }}');
-    M.L2 && (M.L2.textContent = dFormat);
-    M.L3 && (M.L3.textContent = 'Beginner-friendly');
-    M.R1 && (M.R1.textContent = dGroup, M.R1.removeAttribute('href'), M.R1.removeAttribute('target'), M.R1.removeAttribute('rel'));
-    M.R2 && (M.R2.textContent = dDuration, M.R2.removeAttribute('href'));
-    M.R3 && (M.R3.textContent = dPrice);
+    if (M.line1){ M.line1.removeAttribute('hidden'); }
+    if (M.L1) M.L1.textContent = dFormat;
+    if (M.A1){ M.A1.hidden = true; M.A1.removeAttribute('href'); }
+
+    if (M.line2){ M.line2.removeAttribute('hidden'); }
+    if (M.L2) M.L2.textContent = dDuration;
+    if (M.A2){ M.A2.hidden = true; M.A2.removeAttribute('href'); }
+
+    if (M.L3){
+      const bits = [dDiff, dGroup, dPrice].filter(Boolean);
+      M.L3.textContent = bits.join(' · ');
+      if (M.line3){
+        if (bits.length){ M.line3.removeAttribute('hidden'); }
+        else { M.line3.setAttribute('hidden',''); }
+      }
+    }
   }
 
   // Microbar show when scrolled past banner/title area (mobile only)
@@ -198,6 +244,9 @@
     window.addEventListener('resize', update);
     window.__updateMicrobarVis = update;
   })();
+
+  updateFabSpacing();
+  window.addEventListener('resize', ()=>{ updateFabSpacing(); });
 
   // Share handlers
   (function(){

--- a/_includes/scripts-event-core.html
+++ b/_includes/scripts-event-core.html
@@ -261,28 +261,10 @@
     shareFab?.addEventListener('click', sharePage);
   })();
 
-  // Contact phone chooser (same across site; kept here for event pages)
-  (function(){
-    const phone = document.getElementById('phone-link');
-    const menu  = document.getElementById('phone-menu');
-    const waBtn = document.getElementById('wa-now');
-    if (!phone || !menu || !waBtn) return;
-    const tel = (phone.dataset.tel || '').replace(/[^\d]/g,'');
-    const msg = encodeURIComponent("Hi! I'd like to know more about Games Lab events.");
-    waBtn.href = `https://wa.me/${tel}?text=${msg}`;
-    function openMenu(){
-      if (!menu.hidden){ menu.hidden = true; return; }
-      menu.hidden = false;
-      const onAway = (e)=>{ if (!menu.contains(e.target) && e.target !== phone){ menu.hidden = true; cleanup(); } };
-      const onEsc  = (e)=>{ if (e.key === 'Escape'){ menu.hidden = true; cleanup(); } };
-      function cleanup(){ document.removeEventListener('click', onAway, true); document.removeEventListener('keydown', onEsc, true); }
-      document.addEventListener('click', onAway, true);
-      document.addEventListener('keydown', onEsc, true);
-    }
-    phone.addEventListener('click', (e)=>{ e.preventDefault(); openMenu(); });
-  })();
 })();
 </script>
+
+{% include scripts-contact-phone.html %}
 
 <!-- Video Lightbox -->
 <script>

--- a/_includes/scripts-event-core.html
+++ b/_includes/scripts-event-core.html
@@ -80,6 +80,7 @@
   const scDir     = document.getElementById('scDir');
   const scBook    = document.getElementById('scBook');
   const fabBook   = document.getElementById('fabBook');
+  const shareFab  = document.getElementById('shareFab');
 
   // Microbar parts
   const M = {
@@ -99,6 +100,17 @@
   const dGroup = "{{ page.highlights.group_size | default: '8–25 players' | escape }}";
   const dDiff = "{{ page.highlights.difficulty | default: 'Beginner-friendly' | escape }}";
   const dPrice = "{{ page.highlights.price | default: '₹ 350/-' | escape }}";
+
+  function updateShareOffset(){
+    if (!shareFab) return;
+    let bottom = 12;
+    if (fabBook && !fabBook.hasAttribute('hidden')){
+      const height = fabBook.getBoundingClientRect().height || fabBook.offsetHeight || 0;
+      if (!height){ requestAnimationFrame(updateShareOffset); return; }
+      bottom += Math.round(height + 8);
+    }
+    document.documentElement.style.setProperty('--fab-share-bottom', bottom + 'px');
+  }
 
   if (match){
     scheduled = CLEAN(match['Scheduled']).toLowerCase() === 'yes';
@@ -124,18 +136,26 @@
     if (scDir && locLink){ scDir.href = locLink; }
     if (ticket){
       scBook && (scBook.href = ticket);
-      if (fabBook){ fabBook.href = ticket; fabBook.removeAttribute('hidden'); }
+      if (fabBook){
+        fabBook.href = ticket;
+        fabBook.removeAttribute('hidden');
+        requestAnimationFrame(updateShareOffset);
+      } else {
+        updateShareOffset();
+      }
       document.documentElement.style.setProperty('--mobile-bottom-pad', '96px');
     } else {
-      fabBook && fabBook.setAttribute('hidden', '');
+      if (fabBook){ fabBook.setAttribute('hidden', ''); }
       document.documentElement.style.setProperty('--mobile-bottom-pad', '16px');
+      updateShareOffset();
     }
   } else {
     // Not scheduled
     scHeading && scHeading.setAttribute('hidden','');
     if (scBlock) scBlock.hidden = true;
-    fabBook && fabBook.setAttribute('hidden','');
+    if (fabBook){ fabBook.setAttribute('hidden',''); }
     document.documentElement.style.setProperty('--mobile-bottom-pad', '16px');
+    updateShareOffset();
   }
 
   // Microbar content + visibility
@@ -189,7 +209,7 @@
       }catch(e){}
     }
     document.getElementById('shareBtnSide')?.addEventListener('click', sharePage);
-    document.getElementById('shareFab')?.addEventListener('click', sharePage);
+    shareFab?.addEventListener('click', sharePage);
   })();
 
   // Contact phone chooser (same across site; kept here for event pages)

--- a/_includes/styles-event.html
+++ b/_includes/styles-event.html
@@ -1,7 +1,7 @@
 <style>
 :root {
   --bg:#181818; --card:#212121; --muted:#d0d0d0; --accent:#fce029; --datebox:#303030; --text-main:#fff;
-  --topbar-height-desktop:58px; --topbar-height-mobile:48px;
+  --topbar-height-desktop:58px; --topbar-height-mobile:48px; --fab-share-bottom:12px;
 }
 
 /* Base + topbar */
@@ -104,10 +104,10 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
 @media (min-width:960px){.mobile-info-bar{display:none !important}}
 
 /* FABs (mobile) */
-.fab-book,.fab-share{position:fixed;z-index:10000;bottom:12px;border-radius:999px;box-shadow:0 6px 18px rgba(0,0,0,.35);display:flex;align-items:center;gap:10px;padding:12px 16px;text-decoration:none}
-.fab-book{left:12px;right:calc(12px + 56px + 8px);background:var(--accent);color:#000;font-weight:900}
+.fab-book,.fab-share{position:fixed;z-index:10000;border-radius:999px;box-shadow:0 6px 18px rgba(0,0,0,.35);display:flex;align-items:center;gap:10px;padding:12px 16px;text-decoration:none}
+.fab-book{left:12px;right:calc(12px + 56px + 8px);bottom:12px;background:var(--accent);color:#000;font-weight:900;justify-content:center;text-align:center}
 .fab-book[hidden]{display:none}
-.fab-share{right:12px;background:rgba(24,24,24,.35);color:var(--text-main);border:1px solid rgba(255,255,255,.25);-webkit-backdrop-filter:blur(10px);backdrop-filter:blur(10px)}
+.fab-share{right:12px;bottom:var(--fab-share-bottom,12px);background:rgba(24,24,24,.35);color:var(--text-main);border:1px solid rgba(255,255,255,.25);-webkit-backdrop-filter:blur(10px);backdrop-filter:blur(10px)}
 .fab-share .fab-share-label{font-weight:900;font-size:.95rem}
 @media (prefers-color-scheme: light){.fab-share{background:rgba(255,255,255,.65);border-color:rgba(0,0,0,.15);color:inherit}}
 @media (min-width:960px){.fab-book,.fab-share{display:none}}
@@ -115,11 +115,26 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
 /* Ensure desktop has no extra bottom padding */
 @media (min-width:960px){ .wrap{ --mobile-bottom-pad: 16px; } }
 
-/* Contact drop-up menu (above the number) */
+/* Contact section */
+.title{text-align:center}
+.contact-wrap{max-width:1200px;margin:0 auto;padding:0 12px}
+.contact-head{display:flex;align-items:center;gap:12px;margin-bottom:18px;justify-content:center}
+.contact-head .logo-lg{width:44px;height:44px;border-radius:10px;object-fit:cover}
+.contact-sub{margin:0;font-weight:700;letter-spacing:.6px;color:var(--muted)}
+.contact-list{list-style:none;margin:0;padding:0;display:grid;gap:16px}
+.row{display:grid;grid-template-columns:28px 1fr;column-gap:12px;align-items:center}
+.icon{width:28px;height:28px;color:var(--accent)}
+.link{color:var(--text-main);text-decoration:none;font-weight:700}
+.link:hover{color:var(--accent)}
+.email-text{overflow-wrap:anywhere;word-break:break-word;line-break:anywhere}
 .phone-wrap{position:relative}
-.phone-menu{position:absolute;bottom:100%;left:40px;margin-bottom:6px;background:var(--card);border-radius:10px;box-shadow:0 8px 24px rgba(0,0,0,.4);padding:8px;display:flex;gap:8px;z-index:5}
+.phone-menu{position:absolute;top:100%;left:40px;margin-top:6px;background:var(--card);border-radius:10px;box-shadow:0 8px 24px rgba(0,0,0,.4);padding:8px;display:flex;gap:8px;z-index:5}
 .phone-menu[hidden]{display:none}
 .phone-menu a{display:inline-block;padding:8px 12px;border-radius:8px;text-decoration:none;font-weight:700;background:rgba(255,255,255,.06);color:var(--text-main) !important}
 .phone-menu a:hover{background:rgba(255,255,255,.12);color:var(--accent) !important}
+@media (min-width:1100px){
+  .contact-list{display:flex;justify-content:center;flex-wrap:wrap;gap:24px 32px}
+  .row{display:flex;gap:12px}
+}
 @media (prefers-color-scheme: light){.phone-menu{box-shadow:0 8px 24px rgba(0,0,0,.12)}}
 </style>

--- a/_includes/styles-event.html
+++ b/_includes/styles-event.html
@@ -123,24 +123,5 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
 
 /* Contact section */
 .title{text-align:center}
-.contact-wrap{max-width:1200px;margin:0 auto;padding:0 12px}
-.contact-head{display:flex;align-items:center;gap:12px;margin-bottom:18px;justify-content:center}
-.contact-head .logo-lg{width:44px;height:44px;border-radius:10px;object-fit:cover}
-.contact-sub{margin:0;font-weight:700;letter-spacing:.6px;color:var(--muted)}
-.contact-list{list-style:none;margin:0;padding:0;display:grid;gap:16px}
-.row{display:grid;grid-template-columns:28px 1fr;column-gap:12px;align-items:center}
-.icon{width:28px;height:28px;color:var(--accent)}
-.link{color:var(--text-main);text-decoration:none;font-weight:700}
-.link:hover{color:var(--accent)}
-.email-text{overflow-wrap:anywhere;word-break:break-word;line-break:anywhere}
-.phone-wrap{position:relative}
-.phone-menu{position:absolute;top:100%;left:40px;margin-top:6px;background:var(--card);border-radius:10px;box-shadow:0 8px 24px rgba(0,0,0,.4);padding:8px;display:flex;gap:8px;z-index:5}
-.phone-menu[hidden]{display:none}
-.phone-menu a{display:inline-block;padding:8px 12px;border-radius:8px;text-decoration:none;font-weight:700;background:rgba(255,255,255,.06);color:var(--text-main) !important}
-.phone-menu a:hover{background:rgba(255,255,255,.12);color:var(--accent) !important}
-@media (min-width:1100px){
-  .contact-list{display:flex;justify-content:center;flex-wrap:wrap;gap:24px 32px}
-  .row{display:flex;gap:12px}
-}
-@media (prefers-color-scheme: light){.phone-menu{box-shadow:0 8px 24px rgba(0,0,0,.12)}}
+{% include styles/contact.css %}
 </style>

--- a/_includes/styles-event.html
+++ b/_includes/styles-event.html
@@ -98,14 +98,14 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
 }
 
 /* Microbar (mobile only) */
-.mobile-info-bar{position:fixed;left:0;right:0;top:calc(var(--topbar-height-mobile) + env(safe-area-inset-top,0px));z-index:10001;padding:8px 12px;background:rgba(24,24,24,.07);border-bottom:1px solid rgba(255,255,255,.3);-webkit-backdrop-filter:blur(10px);backdrop-filter:blur(10px);transform:translate3d(0,-100%,0);opacity:0;pointer-events:none;transition:transform .2s ease, opacity .15s ease;will-change:transform,opacity}
+.mobile-info-bar{position:fixed;left:0;right:0;top:calc(var(--topbar-height-mobile) + env(safe-area-inset-top,0px));z-index:10001;padding:6px 12px;background:rgba(24,24,24,.07);border-bottom:1px solid rgba(255,255,255,.3);-webkit-backdrop-filter:blur(10px);backdrop-filter:blur(10px);transform:translate3d(0,-100%,0);opacity:0;pointer-events:none;transition:transform .2s ease, opacity .15s ease;will-change:transform,opacity}
 @media (prefers-color-scheme: light){.mobile-info-bar{background:rgba(255,255,255,.55);border-bottom:1px solid rgba(0,0,0,.08)}}
 .mobile-info-bar.show{transform:translate3d(0,0,0);opacity:1;pointer-events:auto}
-.mobile-info-inner{display:flex;flex-direction:column;align-items:flex-start;gap:6px;max-width:1200px;margin:0 auto}
-.micro-title{font-size:1.08rem;font-weight:900;line-height:1.2}
-.micro-line{display:flex;align-items:baseline;gap:12px;width:100%;flex-wrap:nowrap}
-.micro-meta{font-size:.88rem;color:var(--muted);font-weight:800;flex:1;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-.micro-action{font-size:.84rem;color:var(--muted);font-weight:800;text-decoration:underline;text-underline-offset:3px;margin-left:auto;white-space:nowrap}
+.mobile-info-inner{display:flex;flex-direction:column;align-items:flex-start;gap:4px;max-width:1200px;margin:0 auto}
+.micro-title{font-size:1.02rem;font-weight:900;line-height:1.15}
+.micro-line{display:flex;align-items:center;gap:10px;width:100%;flex-wrap:nowrap}
+.micro-meta{font-size:.84rem;color:var(--muted);font-weight:800;line-height:1.2;flex:1;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.micro-action{font-size:.82rem;color:var(--muted);font-weight:800;text-decoration:underline;text-underline-offset:2px;margin-left:auto;white-space:nowrap}
 .micro-action[hidden]{display:none}
 .micro-line:empty{display:none}
 .micro-line span:empty{display:none}

--- a/_includes/styles-event.html
+++ b/_includes/styles-event.html
@@ -31,6 +31,7 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
 
 /* Divider */
 .divider{width:100%;height:1px;margin:26px 0;background:linear-gradient(90deg,rgba(255,255,255,.06),rgba(255,255,255,.02));box-shadow:0 1px 0 rgba(255,255,255,.02) inset;border-radius:1px;backdrop-filter:blur(2px);-webkit-backdrop-filter:blur(2px)}
+.page-grid>.divider{margin:14px 0}
 @media (prefers-color-scheme: light){
   .divider{background:linear-gradient(90deg,rgba(0,0,0,.12),rgba(0,0,0,.06));box-shadow:0 1px 0 rgba(0,0,0,.06) inset;}
 }

--- a/_includes/styles-event.html
+++ b/_includes/styles-event.html
@@ -122,6 +122,5 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
 @media (min-width:960px){.fab-book,.fab-share{display:none}}
 
 /* Contact section */
-.title{text-align:center}
 {% include styles/contact.css %}
 </style>

--- a/_includes/styles-event.html
+++ b/_includes/styles-event.html
@@ -24,15 +24,19 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
 }
 
 /* Layout */
-.wrap{max-width:1200px;margin:0 auto;padding:20px 18px var(--mobile-bottom-pad,16px)}
+.wrap{max-width:1200px;margin:0 auto;padding:20px 18px calc(var(--mobile-bottom-pad,16px) + env(safe-area-inset-bottom,0px));box-sizing:border-box}
 @media (min-width:769px){.wrap{padding-top:12px}}
-@media (max-width:768px){.wrap{padding:14px 12px var(--mobile-bottom-pad,16px)}}
+@media (max-width:768px){.wrap{padding:14px 12px calc(var(--mobile-bottom-pad,16px) + env(safe-area-inset-bottom,0px))}}
+@media (min-width:960px){.wrap{padding-bottom:24px}}
 
 /* Divider */
-.divider{width:100%;height:1px;margin:28px 0 18px;background:linear-gradient(90deg,rgba(255,255,255,.06),rgba(255,255,255,.02));box-shadow:0 1px 0 rgba(255,255,255,.02) inset;border-radius:1px;backdrop-filter:blur(2px);-webkit-backdrop-filter:blur(2px)}
+.divider{width:100%;height:1px;margin:26px 0;background:linear-gradient(90deg,rgba(255,255,255,.06),rgba(255,255,255,.02));box-shadow:0 1px 0 rgba(255,255,255,.02) inset;border-radius:1px;backdrop-filter:blur(2px);-webkit-backdrop-filter:blur(2px)}
 @media (prefers-color-scheme: light){
   .divider{background:linear-gradient(90deg,rgba(0,0,0,.12),rgba(0,0,0,.06));box-shadow:0 1px 0 rgba(0,0,0,.06) inset;}
 }
+
+.section-divider{margin:26px 0}
+.divider-left{width:160px;max-width:60%;margin-left:0;margin-right:auto}
 
 /* Grid */
 .page-grid{display:grid;grid-template-columns:1fr;grid-template-areas:"banner" "title" "tagline" "divider" "content";gap:12px}
@@ -55,6 +59,8 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
 
 /* Content */
 .content{grid-area:content}
+.section-title{margin:0 0 16px;font-size:1.12rem;letter-spacing:.6px;text-transform:uppercase;font-weight:900}
+.closing-note{margin-bottom:6px}
 .prose{font-size:1.04rem;line-height:1.7}
 .prose p{margin:0 0 16px}
 
@@ -94,26 +100,25 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
 .mobile-info-bar{position:fixed;left:0;right:0;top:calc(var(--topbar-height-mobile) + env(safe-area-inset-top,0px));z-index:10001;padding:8px 12px;background:rgba(24,24,24,.07);border-bottom:1px solid rgba(255,255,255,.3);-webkit-backdrop-filter:blur(10px);backdrop-filter:blur(10px);transform:translate3d(0,-100%,0);opacity:0;pointer-events:none;transition:transform .2s ease, opacity .15s ease;will-change:transform,opacity}
 @media (prefers-color-scheme: light){.mobile-info-bar{background:rgba(255,255,255,.55);border-bottom:1px solid rgba(0,0,0,.08)}}
 .mobile-info-bar.show{transform:translate3d(0,0,0);opacity:1;pointer-events:auto}
-.mobile-info-inner{display:flex;align-items:center;justify-content:space-between;gap:10px;max-width:1200px;margin:0 auto;flex-wrap:nowrap}
-.microbar-left{display:flex;flex-direction:column;align-items:flex-start;gap:2px;min-width:0}
-.microbar-right{display:flex;flex-direction:column;align-items:flex-end;gap:4px}
-.micro-title{font-size:1.12rem;font-weight:900;line-height:1.2}
-.micro-meta-line{font-size:.98rem;color:var(--muted);font-weight:800}
-.microbar-link{font-size:.87rem;color:var(--muted);font-weight:700;text-decoration:none}
+.mobile-info-inner{display:flex;flex-direction:column;align-items:flex-start;gap:6px;max-width:1200px;margin:0 auto}
+.micro-title{font-size:1.08rem;font-weight:900;line-height:1.2}
+.micro-line{display:flex;align-items:baseline;gap:12px;flex-wrap:wrap}
+.micro-meta{font-size:.88rem;color:var(--muted);font-weight:800}
+.micro-action{font-size:.84rem;color:var(--muted);font-weight:800;text-decoration:underline;text-underline-offset:3px}
+.micro-action[hidden]{display:none}
+.micro-line:empty{display:none}
+.micro-line span:empty{display:none}
 @media (min-width:601px){.mobile-info-bar{top:calc(var(--topbar-height-desktop) + env(safe-area-inset-top,0px))}}
 @media (min-width:960px){.mobile-info-bar{display:none !important}}
 
 /* FABs (mobile) */
 .fab-book,.fab-share{position:fixed;z-index:10000;border-radius:999px;box-shadow:0 6px 18px rgba(0,0,0,.35);display:flex;align-items:center;gap:10px;padding:12px 16px;text-decoration:none}
-.fab-book{left:12px;right:calc(12px + 56px + 8px);bottom:12px;background:var(--accent);color:#000;font-weight:900;justify-content:center;text-align:center}
+.fab-book{left:12px;right:12px;bottom:6px;background:var(--accent);color:#000;font-weight:900;justify-content:center;text-align:center}
 .fab-book[hidden]{display:none}
 .fab-share{right:12px;bottom:var(--fab-share-bottom,12px);background:rgba(24,24,24,.35);color:var(--text-main);border:1px solid rgba(255,255,255,.25);-webkit-backdrop-filter:blur(10px);backdrop-filter:blur(10px)}
 .fab-share .fab-share-label{font-weight:900;font-size:.95rem}
 @media (prefers-color-scheme: light){.fab-share{background:rgba(255,255,255,.65);border-color:rgba(0,0,0,.15);color:inherit}}
 @media (min-width:960px){.fab-book,.fab-share{display:none}}
-
-/* Ensure desktop has no extra bottom padding */
-@media (min-width:960px){ .wrap{ --mobile-bottom-pad: 16px; } }
 
 /* Contact section */
 .title{text-align:center}

--- a/_includes/styles-event.html
+++ b/_includes/styles-event.html
@@ -103,9 +103,9 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
 .mobile-info-bar.show{transform:translate3d(0,0,0);opacity:1;pointer-events:auto}
 .mobile-info-inner{display:flex;flex-direction:column;align-items:flex-start;gap:6px;max-width:1200px;margin:0 auto}
 .micro-title{font-size:1.08rem;font-weight:900;line-height:1.2}
-.micro-line{display:flex;align-items:baseline;gap:12px;flex-wrap:wrap}
-.micro-meta{font-size:.88rem;color:var(--muted);font-weight:800}
-.micro-action{font-size:.84rem;color:var(--muted);font-weight:800;text-decoration:underline;text-underline-offset:3px}
+.micro-line{display:flex;align-items:baseline;gap:12px;width:100%;flex-wrap:nowrap}
+.micro-meta{font-size:.88rem;color:var(--muted);font-weight:800;flex:1;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.micro-action{font-size:.84rem;color:var(--muted);font-weight:800;text-decoration:underline;text-underline-offset:3px;margin-left:auto;white-space:nowrap}
 .micro-action[hidden]{display:none}
 .micro-line:empty{display:none}
 .micro-line span:empty{display:none}

--- a/_includes/styles-event.html
+++ b/_includes/styles-event.html
@@ -2,13 +2,14 @@
 :root {
   --bg:#181818; --card:#212121; --muted:#d0d0d0; --accent:#fce029; --datebox:#303030; --text-main:#fff;
   --topbar-height-desktop:58px; --topbar-height-mobile:48px; --fab-share-bottom:12px;
+  --topbar-chrome-bg:rgba(24,24,24,.82); --topbar-chrome-border:rgba(255,255,255,.18);
 }
 
 /* Base + topbar */
 html,body{margin:0;height:100%}
 body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
-.topbar-bleed{position:fixed;top:0;left:0;right:0;height:env(safe-area-inset-top,0px);background:rgba(24,24,24,.07);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);z-index:10002;pointer-events:none}
-.topbar{position:fixed;top:0;left:0;right:0;display:flex;align-items:center;padding-left:24px;padding-top:env(safe-area-inset-top,0px);height:calc(var(--topbar-height-desktop) + env(safe-area-inset-top,0px));box-sizing:border-box;z-index:10003;border-bottom:1px solid rgba(255,255,255,.3);background:rgba(24,24,24,.07);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px)}
+.topbar-bleed{position:fixed;top:0;left:0;right:0;height:env(safe-area-inset-top,0px);background:var(--topbar-chrome-bg);border-bottom:1px solid var(--topbar-chrome-border);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px);z-index:10002;pointer-events:none}
+.topbar{position:fixed;top:0;left:0;right:0;display:flex;align-items:center;padding-left:24px;padding-top:env(safe-area-inset-top,0px);height:calc(var(--topbar-height-desktop) + env(safe-area-inset-top,0px));box-sizing:border-box;z-index:10003;box-shadow:0 1px 0 var(--topbar-chrome-border);background:var(--topbar-chrome-bg);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px)}
 .topbar-left{display:flex;align-items:center;height:100%}
 .topbar-left.home-link{color:inherit;text-decoration:none}
 .topbar-left.home-link:focus-visible{outline:2px solid var(--accent);outline-offset:4px}
@@ -18,9 +19,8 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
 .topbar-spacer{width:100%;height:calc(var(--topbar-height-desktop) + env(safe-area-inset-top,0px))}
 @media (max-width:600px){.topbar-spacer{height:calc(var(--topbar-height-mobile) + env(safe-area-inset-top,0px))}}
 @media (prefers-color-scheme: light){
-  :root{--bg:#f5f5f5;--card:#fff;--muted:#444;--accent:#0a75bc;--datebox:#ececec;--text-main:#181818}
+  :root{--bg:#f5f5f5;--card:#fff;--muted:#444;--accent:#0a75bc;--datebox:#ececec;--text-main:#181818;--topbar-chrome-bg:rgba(255,255,255,.7);--topbar-chrome-border:rgba(0,0,0,.08)}
   .brand{color:#242424}
-  .topbar,.topbar-bleed{background:rgba(255,255,255,.55)!important;border-bottom:1px solid rgba(0,0,0,.08);-webkit-backdrop-filter:saturate(180%) blur(14px);backdrop-filter:saturate(180%) blur(14px)}
 }
 
 /* Layout */
@@ -98,8 +98,7 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
 }
 
 /* Microbar (mobile only) */
-.mobile-info-bar{position:fixed;left:0;right:0;top:calc(var(--topbar-height-mobile) + env(safe-area-inset-top,0px));z-index:10001;padding:6px 12px 4px;background:rgba(24,24,24,.07);border-bottom:1px solid rgba(255,255,255,.3);-webkit-backdrop-filter:blur(10px);backdrop-filter:blur(10px);transform:translate3d(0,-100%,0);opacity:0;pointer-events:none;transition:transform .2s ease, opacity .15s ease;will-change:transform,opacity}
-@media (prefers-color-scheme: light){.mobile-info-bar{background:rgba(255,255,255,.55);border-bottom:1px solid rgba(0,0,0,.08)}}
+.mobile-info-bar{position:fixed;left:0;right:0;top:calc(var(--topbar-height-mobile) + env(safe-area-inset-top,0px));z-index:10001;padding:6px 12px 4px;background:var(--topbar-chrome-bg);border-bottom:1px solid var(--topbar-chrome-border);-webkit-backdrop-filter:blur(14px);backdrop-filter:blur(14px);transform:translate3d(0,-100%,0);opacity:0;pointer-events:none;transition:transform .2s ease, opacity .15s ease;will-change:transform,opacity}
 .mobile-info-bar.show{transform:translate3d(0,0,0);opacity:1;pointer-events:auto}
 .mobile-info-inner{display:flex;flex-direction:column;align-items:flex-start;gap:4px;max-width:1200px;margin:0 auto}
 .micro-title{font-size:1.02rem;font-weight:900;line-height:1.15}
@@ -111,6 +110,8 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
 .micro-line span:empty{display:none}
 @media (min-width:601px){.mobile-info-bar{top:calc(var(--topbar-height-desktop) + env(safe-area-inset-top,0px))}}
 @media (min-width:960px){.mobile-info-bar{display:none !important}}
+
+@media (max-width:768px){.topbar,.topbar-bleed{transform:translateZ(0);-webkit-transform:translateZ(0)}}
 
 /* FABs (mobile) */
 .fab-book,.fab-share{position:fixed;z-index:10000;border-radius:999px;box-shadow:0 6px 18px rgba(0,0,0,.35);display:flex;align-items:center;gap:10px;padding:12px 16px;text-decoration:none}

--- a/_includes/styles-event.html
+++ b/_includes/styles-event.html
@@ -98,7 +98,7 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
 }
 
 /* Microbar (mobile only) */
-.mobile-info-bar{position:fixed;left:0;right:0;top:calc(var(--topbar-height-mobile) + env(safe-area-inset-top,0px));z-index:10001;padding:6px 12px;background:rgba(24,24,24,.07);border-bottom:1px solid rgba(255,255,255,.3);-webkit-backdrop-filter:blur(10px);backdrop-filter:blur(10px);transform:translate3d(0,-100%,0);opacity:0;pointer-events:none;transition:transform .2s ease, opacity .15s ease;will-change:transform,opacity}
+.mobile-info-bar{position:fixed;left:0;right:0;top:calc(var(--topbar-height-mobile) + env(safe-area-inset-top,0px));z-index:10001;padding:6px 12px 4px;background:rgba(24,24,24,.07);border-bottom:1px solid rgba(255,255,255,.3);-webkit-backdrop-filter:blur(10px);backdrop-filter:blur(10px);transform:translate3d(0,-100%,0);opacity:0;pointer-events:none;transition:transform .2s ease, opacity .15s ease;will-change:transform,opacity}
 @media (prefers-color-scheme: light){.mobile-info-bar{background:rgba(255,255,255,.55);border-bottom:1px solid rgba(0,0,0,.08)}}
 .mobile-info-bar.show{transform:translate3d(0,0,0);opacity:1;pointer-events:auto}
 .mobile-info-inner{display:flex;flex-direction:column;align-items:flex-start;gap:4px;max-width:1200px;margin:0 auto}

--- a/_includes/styles-event.html
+++ b/_includes/styles-event.html
@@ -2,14 +2,13 @@
 :root {
   --bg:#181818; --card:#212121; --muted:#d0d0d0; --accent:#fce029; --datebox:#303030; --text-main:#fff;
   --topbar-height-desktop:58px; --topbar-height-mobile:48px; --fab-share-bottom:12px;
-  --topbar-chrome-bg:rgba(24,24,24,.82); --topbar-chrome-border:rgba(255,255,255,.18);
 }
 
 /* Base + topbar */
 html,body{margin:0;height:100%}
 body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
-.topbar-bleed{position:fixed;top:0;left:0;right:0;height:env(safe-area-inset-top,0px);background:var(--topbar-chrome-bg);border-bottom:1px solid var(--topbar-chrome-border);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px);z-index:10002;pointer-events:none}
-.topbar{position:fixed;top:0;left:0;right:0;display:flex;align-items:center;padding-left:24px;padding-top:env(safe-area-inset-top,0px);height:calc(var(--topbar-height-desktop) + env(safe-area-inset-top,0px));box-sizing:border-box;z-index:10003;box-shadow:0 1px 0 var(--topbar-chrome-border);background:var(--topbar-chrome-bg);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px)}
+.topbar-bleed{position:fixed;top:0;left:0;right:0;height:env(safe-area-inset-top,0px);background:rgba(24,24,24,.07);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);z-index:10002;pointer-events:none}
+.topbar{position:fixed;top:0;left:0;right:0;display:flex;align-items:center;padding-left:24px;padding-top:env(safe-area-inset-top,0px);height:calc(var(--topbar-height-desktop) + env(safe-area-inset-top,0px));box-sizing:border-box;z-index:10003;border-bottom:1px solid rgba(255,255,255,.3);background:rgba(24,24,24,.07);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px)}
 .topbar-left{display:flex;align-items:center;height:100%}
 .topbar-left.home-link{color:inherit;text-decoration:none}
 .topbar-left.home-link:focus-visible{outline:2px solid var(--accent);outline-offset:4px}
@@ -19,8 +18,9 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
 .topbar-spacer{width:100%;height:calc(var(--topbar-height-desktop) + env(safe-area-inset-top,0px))}
 @media (max-width:600px){.topbar-spacer{height:calc(var(--topbar-height-mobile) + env(safe-area-inset-top,0px))}}
 @media (prefers-color-scheme: light){
-  :root{--bg:#f5f5f5;--card:#fff;--muted:#444;--accent:#0a75bc;--datebox:#ececec;--text-main:#181818;--topbar-chrome-bg:rgba(255,255,255,.7);--topbar-chrome-border:rgba(0,0,0,.08)}
+  :root{--bg:#f5f5f5;--card:#fff;--muted:#444;--accent:#0a75bc;--datebox:#ececec;--text-main:#181818}
   .brand{color:#242424}
+  .topbar,.topbar-bleed{background:rgba(255,255,255,.55)!important;border-bottom:1px solid rgba(0,0,0,.08);-webkit-backdrop-filter:saturate(180%) blur(14px);backdrop-filter:saturate(180%) blur(14px)}
 }
 
 /* Layout */
@@ -98,7 +98,8 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
 }
 
 /* Microbar (mobile only) */
-.mobile-info-bar{position:fixed;left:0;right:0;top:calc(var(--topbar-height-mobile) + env(safe-area-inset-top,0px));z-index:10001;padding:6px 12px 4px;background:var(--topbar-chrome-bg);border-bottom:1px solid var(--topbar-chrome-border);-webkit-backdrop-filter:blur(14px);backdrop-filter:blur(14px);transform:translate3d(0,-100%,0);opacity:0;pointer-events:none;transition:transform .2s ease, opacity .15s ease;will-change:transform,opacity}
+.mobile-info-bar{position:fixed;left:0;right:0;top:calc(var(--topbar-height-mobile) + env(safe-area-inset-top,0px));z-index:10001;padding:6px 12px 4px;background:rgba(24,24,24,.07);border-bottom:1px solid rgba(255,255,255,.3);-webkit-backdrop-filter:blur(10px);backdrop-filter:blur(10px);transform:translate3d(0,-100%,0);opacity:0;pointer-events:none;transition:transform .2s ease, opacity .15s ease;will-change:transform,opacity}
+@media (prefers-color-scheme: light){.mobile-info-bar{background:rgba(255,255,255,.55);border-bottom:1px solid rgba(0,0,0,.08)}}
 .mobile-info-bar.show{transform:translate3d(0,0,0);opacity:1;pointer-events:auto}
 .mobile-info-inner{display:flex;flex-direction:column;align-items:flex-start;gap:4px;max-width:1200px;margin:0 auto}
 .micro-title{font-size:1.02rem;font-weight:900;line-height:1.15}
@@ -110,8 +111,6 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
 .micro-line span:empty{display:none}
 @media (min-width:601px){.mobile-info-bar{top:calc(var(--topbar-height-desktop) + env(safe-area-inset-top,0px))}}
 @media (min-width:960px){.mobile-info-bar{display:none !important}}
-
-@media (max-width:768px){.topbar,.topbar-bleed{transform:translateZ(0);-webkit-transform:translateZ(0)}}
 
 /* FABs (mobile) */
 .fab-book,.fab-share{position:fixed;z-index:10000;border-radius:999px;box-shadow:0 6px 18px rgba(0,0,0,.35);display:flex;align-items:center;gap:10px;padding:12px 16px;text-decoration:none}

--- a/_includes/styles/contact.css
+++ b/_includes/styles/contact.css
@@ -1,0 +1,22 @@
+.contact-wrap{max-width:1200px;margin:0 auto;padding:0 12px;}
+.contact-head{display:flex;align-items:center;gap:12px;margin-bottom:18px;justify-content:center;}
+.contact-head .logo-lg{width:44px;height:44px;border-radius:10px;object-fit:cover;}
+.contact-sub{margin:0;font-weight:700;letter-spacing:.6px;color:var(--muted);}
+.contact-list{list-style:none;margin:0;padding:0;display:grid;gap:16px;}
+.row{display:grid;grid-template-columns:28px 1fr;column-gap:12px;align-items:center;}
+.icon{width:28px;height:28px;color:var(--accent);}
+.link{color:var(--text-main);text-decoration:none;font-weight:700;}
+.link:hover{color:var(--accent);}
+.email-text{overflow-wrap:anywhere;word-break:break-word;line-break:anywhere;}
+.phone-wrap{position:relative;}
+.phone-menu{position:absolute;top:100%;left:40px;margin-top:6px;background:var(--card);border-radius:10px;box-shadow:0 8px 24px rgba(0,0,0,.4);padding:8px;display:flex;gap:8px;z-index:5;}
+.phone-menu[hidden]{display:none;}
+.phone-menu a{display:inline-block;padding:8px 12px;border-radius:8px;text-decoration:none;font-weight:700;background:rgba(255,255,255,.06);color:var(--text-main) !important;}
+.phone-menu a:hover{background:rgba(255,255,255,.12);color:var(--accent) !important;}
+@media (min-width:1100px){
+  .contact-list{display:flex;justify-content:center;flex-wrap:wrap;gap:24px 32px;}
+  .row{display:flex;gap:12px;}
+}
+@media (prefers-color-scheme: light){
+  .phone-menu{box-shadow:0 8px 24px rgba(0,0,0,.12);}
+}

--- a/_includes/styles/contact.css
+++ b/_includes/styles/contact.css
@@ -1,3 +1,5 @@
+.title{text-align:center;margin-bottom:18px;}
+.title h2{color:var(--accent);margin:0;font-size:1.9rem;font-weight:700;letter-spacing:.2px;}
 .contact-wrap{max-width:1200px;margin:0 auto;padding:0 12px;}
 .contact-head{display:flex;align-items:center;gap:12px;margin-bottom:18px;justify-content:center;}
 .contact-head .logo-lg{width:44px;height:44px;border-radius:10px;object-fit:cover;}
@@ -13,6 +15,7 @@
 .phone-menu[hidden]{display:none;}
 .phone-menu a{display:inline-block;padding:8px 12px;border-radius:8px;text-decoration:none;font-weight:700;background:rgba(255,255,255,.06);color:var(--text-main) !important;}
 .phone-menu a:hover{background:rgba(255,255,255,.12);color:var(--accent) !important;}
+.contact-wrap #phone-link{-webkit-tap-highlight-color:transparent;touch-action:manipulation;}
 @media (min-width:1100px){
   .contact-list{display:flex;justify-content:center;flex-wrap:wrap;gap:24px 32px;}
   .row{display:flex;gap:12px;}

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -16,10 +16,8 @@
       {% include event-sections.html %}
     </div>
 
-    <!-- Divider used to keep FAB off the footer on some pages; JS will set bottom padding via CSS var -->
-    <div class="divider" id="contactTopDivider" style="margin-top:40px;"></div>
+    {% include divider.html mt='40px' %}
     {% include contact.html %}
-    <div class="divider" style="margin-top:40px;"></div>
   </main>
 
   <!-- Video Lightbox Modal -->


### PR DESCRIPTION
## Summary
- align the event page contact section styling with the homepage version, including restored phone menu layout
- render event detail sections from front matter markdown blocks so each experience shows its content
- adjust mobile FAB spacing so Share rises above Book Now when visible and center the Book Now label

## Testing
- bundle exec jekyll build *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68d543761e7c832caa9615e1dc5eef30