### PR TITLE
Fix mobile upcoming card layout

### DIFF
--- a/.github/workflows/update-calendar.yml
+++ b/.github/workflows/update-calendar.yml
@@ -1,0 +1,35 @@
+name: Update calendar feed
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate calendar artifact
+        run: npm run build:calendar
+        env:
+          CALENDAR_ICS_URL: ${{ secrets.CALENDAR_ICS_URL }}
+
+      - name: Commit and push changes
+        run: |
+          if [[ -n "$(git status --porcelain assets/data/calendar.json)" ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add assets/data/calendar.json
+            git commit -m "chore: update calendar feed"
+            git push
+          else
+            echo "No calendar updates to commit."
+          fi

--- a/_data/locations.yml
+++ b/_data/locations.yml
@@ -1,18 +1,12 @@
-647eaa37a88237012ccbcee1:
-  name: "Dialogues Cafe, Koramangala"
+- name: "Dialogues Cafe"
   map_url: "https://maps.app.goo.gl/iL4GWxFT7PQ13xtCA"
-68715f6c9e06c9ae6ae774db:
-  name: "Big Bean Cafe, Koramangala"
+- name: "Big Bean Cafe"
   map_url: "https://maps.app.goo.gl/SN7w4itJnqGMP2Qw9"
-66fa0b96ddb41d3b8f271db9:
-  name: "Cafe Du L'Amour, Koramangala"
+- name: "Cafe Du L'Amour"
   map_url: "https://maps.app.goo.gl/vh3Pv3Y9UgYhEFuK7"
-6471d4623b9998968e53de62:
-  name: "SLAY Coffee, HSR Layout"
+- name: "SLAY Coffee"
   map_url: "https://maps.app.goo.gl/m44qdH19FcHfErqk7"
-65b5c92172f817df087ba12f:
-  name: "The Coffee Brewery, Koramangala"
+- name: "The Coffee Brewery"
   map_url: "https://maps.app.goo.gl/8gpKvEDMUzYUwyKv7"
-647e2001f6e959ec5e86ad76:
-  name: "Now Boarding Cafe, Jayanagar"
+- name: "Now Boarding Cafe"
   map_url: "https://maps.app.goo.gl/11Y7eLoUekZf8M4KA"

--- a/_includes/cards-explore.html
+++ b/_includes/cards-explore.html
@@ -2,26 +2,14 @@
 <div id="explore-cards" class="cards-row"></div>
 <script>
 (function(){
-  const EVENTS = [
-  {% for event in site.events %}
-    {% unless event.draft or event.published == false %}
-    {
-      slug: {{ event.data.slug | default: event.slug | jsonify }},
-      title: {{ event.title | jsonify }},
-      intro: {{ event.intro | default: event.tagline | default: '' | jsonify }},
-      banner: {{ event.banner | default: event.hero_image | jsonify }},
-      url: {{ event.url | relative_url | jsonify }},
-      order: {{ event.card_order | default: event.order | default: forloop.index0 | jsonify }}
-    }{% unless forloop.last %},{% endunless %}
-    {% endunless %}
-  {% endfor %}
-  ].filter(Boolean);
+  const BASEURL = "{{ site.baseurl | default: '' }}";
+  const CALENDAR_URL = BASEURL + "/assets/data/calendar.json";
+  const EVENTS = window.__EVENTS_METADATA || (window.__EVENTS_METADATA = {% include events-metadata.json %});
 
   const container = document.getElementById('explore-cards');
   if (!container) return;
 
   const fallbackImage = "https://via.placeholder.com/800x450?text=Event+Image";
-  const upcomingCsv = "https://docs.google.com/spreadsheets/d/e/2PACX-1vSs9vlFaLhdFNFXvWsBIXlAJu0J5Dj2deY_7SlwAGd9Jk1-djK6xP3rdXim7Co0BJ-pUJueDCYYugew/pub?gid=1356004046&single=true&output=csv";
 
   if (!EVENTS.length){
     container.innerHTML = '<div style="color:#bbb;text-align:center;">No events have been published yet.</div>';
@@ -37,22 +25,14 @@
 
   setSkeletons(container, Math.min(EVENTS.length, 3));
 
-  function clean(value){
-    if (value == null) return '';
-    return String(value).trim().replace(/^"|"$/g,'');
-  }
-
   function normalizeSlug(value){
     if (!value) return '';
-    return value.toString().toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-+|-+$/g,'');
-  }
-
-  function slugFromUrl(url){
-    if (!url) return '';
-    const path = url.replace(/^https?:\/\/[^/]+/i,'').replace(/^\/+|\/+$/g,'');
-    if (!path) return '';
-    const segments = path.split('/');
-    return normalizeSlug(segments[segments.length - 1] || '');
+    return value.toString()
+      .normalize('NFKD')
+      .replace(/[\u0300-\u036f]/g,'')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g,'-')
+      .replace(/^-+|-+$/g,'');
   }
 
   function withTransform(url){
@@ -136,47 +116,18 @@
     }
   }
 
-  fetch(upcomingCsv + '&cb=' + Date.now(), { cache: 'no-store' })
+  fetch(CALENDAR_URL + '?v=' + Date.now(), { cache: 'no-store' })
     .then(res => {
-      if (!res.ok) throw new Error('Failed to load upcoming events CSV');
-      return res.text();
+      if (!res.ok) throw new Error('Failed to load calendar artifact');
+      return res.json();
     })
-    .then(text => {
-      const parsed = Papa.parse(text, { skipEmptyLines: true });
-      const rows = parsed.data || [];
-      if (!rows.length){
-        renderCards(new Set());
-        return;
-      }
-      const header = rows[0].map(h => clean(h).toLowerCase());
-      const findIndex = (...candidates) => {
-        for (let i = 0; i < header.length; i++){
-          if (candidates.includes(header[i])) return i;
-        }
-        return -1;
-      };
-      const idxEvent = findIndex('event', 'event name', 'eventname');
-      const idxLink = findIndex('page link', 'pagelink', 'page');
-      const idxScheduled = findIndex('scheduled');
-
+    .then(data => {
       const scheduled = new Set();
-      for (let r = 1; r < rows.length; r++){
-        const row = rows[r];
-        if (!row) continue;
-        if (idxScheduled !== -1){
-          const flag = clean(row[idxScheduled]).toLowerCase();
-          if (flag && flag !== 'yes') continue;
-        }
-        if (idxLink !== -1){
-          const slug = slugFromUrl(clean(row[idxLink]));
-          if (slug) scheduled.add(slug);
-        }
-        if (idxEvent !== -1){
-          const nameSlug = normalizeSlug(clean(row[idxEvent]));
-          if (nameSlug) scheduled.add(nameSlug);
-        }
-      }
-
+      (data.events || []).forEach(entry => {
+        if (!entry) return;
+        const slug = normalizeSlug(entry.slug || entry.title);
+        if (slug) scheduled.add(slug);
+      });
       renderCards(scheduled);
     })
     .catch(err => {

--- a/_includes/cards-upcoming.html
+++ b/_includes/cards-upcoming.html
@@ -2,141 +2,219 @@
 <div id="events" class="cards-row" aria-live="polite"></div>
 <script>
 (async function(){
-  const csvUrl = "https://docs.google.com/spreadsheets/d/e/2PACX-1vSs9vlFaLhdFNFXvWsBIXlAJu0J5Dj2deY_7SlwAGd9Jk1-djK6xP3rdXim7Co0BJ-pUJueDCYYugew/pub?gid=1356004046&single=true&output=csv";
+  const BASEURL = "{{ site.baseurl | default: '' }}";
+  const CALENDAR_URL = BASEURL + "/assets/data/calendar.json";
+  const TIMEZONE = 'Asia/Kolkata';
   const fallbackImage = "https://via.placeholder.com/800x450?text=Event+Image";
   const container = document.getElementById("events");
 
-  // skeleton helpers rely on scripts-skeletons include being loaded globally
+  const EVENTS = window.__EVENTS_METADATA || (window.__EVENTS_METADATA = {% include events-metadata.json %});
+
+  if (!container) return;
+
   setSkeletons(container, 3);
 
-  function clean(v){ if (v==null) return ""; return String(v).trim().replace(/^\"|\"$/g,''); }
-  function parseEventDate(str){
-    if (!str) return null;
-    str = String(str).trim().replace(/^[A-Za-z]{3},?\s*/, '').replace(/’|`/g,"'");
-    let m = str.match(/^(\d{1,2})\s+([A-Za-z]{3})\s+'(\d{2})$/);
-    if (m){ const d=+m[1], mon={Jan:0,Feb:1,Mar:2,Apr:3,May:4,Jun:5,Jul:6,Aug:7,Sep:8,Oct:9,Nov:10,Dec:11}[m[2]], y=2000+ +m[3]; if (mon!=null) return new Date(y,mon,d); }
-    m = str.match(/^(\d{1,2})\s+([A-Za-z]{3})\s+(\d{4})$/);
-    if (m){ const d=+m[1], mon={Jan:0,Feb:1,Mar:2,Apr:3,May:4,Jun:5,Jul:6,Aug:7,Sep:8,Oct:9,Nov:10,Dec:11}[m[2]], y=+m[3]; if (mon!=null) return new Date(y,mon,d); }
-    m = str.match(/^([A-Za-z]{3})\s+(\d{1,2}),\s*(\d{4})$/);
-    if (m){ const mon={Jan:0,Feb:1,Mar:2,Apr:3,May:4,Jun:5,Jul:6,Aug:7,Sep:8,Oct:9,Nov:10,Dec:11}[m[1]], d=+m[2], y=+m[3]; if (mon!=null) return new Date(y,mon,d); }
-    m = str.match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
-    if (m) return new Date(+m[1], +m[2]-1, +m[3]);
-    const d = new Date(str); return isNaN(d) ? null : d;
+  function normalizeSlug(value){
+    if (!value) return '';
+    return value.toString()
+      .normalize('NFKD')
+      .replace(/[\u0300-\u036f]/g,'')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g,'-')
+      .replace(/^-+|-+$/g,'');
+  }
+
+  function withTransform(url){
+    if (!url) return '';
+    if (/\/tr:/.test(url) || /[?&]tr=/.test(url)) return url;
+    if (url.includes('imagekit.io')){
+      return url.replace(/(imagekit\.io\/[^/]+)/, '$1/tr:w-800,h-450,fo-auto');
+    }
+    return url + (url.includes('?') ? '&' : '?') + 'tr=w-800,h-450,fo-auto';
+  }
+
+  const metaBySlug = new Map();
+  const metaByTitle = new Map();
+  EVENTS.forEach(evt => {
+    if (!evt) return;
+    const slug = normalizeSlug(evt.slug || evt.title);
+    if (slug) metaBySlug.set(slug, evt);
+    if (evt.title) metaByTitle.set(evt.title.toLowerCase(), evt);
+  });
+
+  function formatDate(date, timezone){
+    const parts = new Intl.DateTimeFormat('en-US', {
+      weekday: 'short',
+      day: '2-digit',
+      month: 'short',
+      year: '2-digit',
+      timeZone: timezone
+    }).formatToParts(date).reduce((acc, part) => {
+      if (part.type !== 'literal') acc[part.type] = part.value;
+      return acc;
+    }, {});
+    return `${parts.weekday || ''}, ${parts.day || ''} ${parts.month || ''} '${parts.year || ''}`.trim();
+  }
+
+  function formatTime(date, timezone){
+    const str = new Intl.DateTimeFormat('en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: true,
+      timeZone: timezone
+    }).format(date).replace(/\u202f/g, ' ');
+    return str.toUpperCase();
   }
 
   try{
-    const res = await fetch(csvUrl + '&cb=' + Date.now(), { cache: "no-store" });
-    if(!res.ok) throw new Error("CSV fetch failed: " + res.status);
-    const parsed = Papa.parse(await res.text(), {skipEmptyLines:true});
-    const rows = (parsed.data||[]).slice(1).filter(r => r && r[0] && String(r[0]).trim() !== "");
-    const today = new Date(); today.setHours(0,0,0,0);
+    const res = await fetch(CALENDAR_URL + '?v=' + Date.now(), { cache: 'no-store' });
+    if (!res.ok) throw new Error('Calendar fetch failed: ' + res.status);
+    const data = await res.json();
+    const timezone = (typeof data.timezone === 'string' && data.timezone.trim()) || TIMEZONE;
+    const list = Array.isArray(data.events) ? data.events.slice() : [];
 
-    const items = [];
-    rows.sort((a,b)=>{
-      const da = parseEventDate(clean(a[1]));
-      const db = parseEventDate(clean(b[1]));
-      if(!da) return 1; if(!db) return -1; return da - db;
-    }).forEach(cols=>{
-      const dateObj = parseEventDate(clean(cols[1]));
-      if(!dateObj) return;
-      dateObj.setHours(0,0,0,0);
-      if(dateObj < today) return;
-      items.push(cols);
+    list.sort((a, b) => {
+      const da = a?.start ? new Date(a.start) : null;
+      const db = b?.start ? new Date(b.start) : null;
+      if (!da) return 1;
+      if (!db) return -1;
+      return da - db;
     });
 
-    if (items.length > 0) setSkeletons(container, items.length);
+    if (list.length > 0) setSkeletons(container, list.length);
 
-    items.forEach((cols, idx)=>{
-      const name = clean(cols[0]);
-      const date = clean(cols[1]);
-      const time = clean(cols[2]);
-      const locText = clean(cols[3]);
-      const pageLink = clean(cols[4]);
-      const image = clean(cols[8]) || fallbackImage;
-      const eventDateObj = parseEventDate(date);
+    list.forEach((entry, idx) => {
+      if (!entry) return;
+      const slug = normalizeSlug(entry.slug || entry.title);
+      const meta = (slug && metaBySlug.get(slug)) || (entry.title ? metaByTitle.get(entry.title.toLowerCase()) : null);
+      const title = meta?.title || entry.title || 'Untitled Event';
+      const card = document.createElement('article');
+      card.className = 'card';
 
-      const card = document.createElement("article");
-      card.className = "card";
-
-      const media = document.createElement("div");
-      media.className = "media";
-      const img = document.createElement("img");
-      img.loading = "lazy"; img.src = image; img.alt = name || "Event image";
+      const media = document.createElement('div');
+      media.className = 'media';
+      const img = document.createElement('img');
+      const banner = meta?.banner ? withTransform(meta.banner) : fallbackImage;
+      img.loading = 'lazy';
+      img.src = banner || fallbackImage;
+      img.alt = title || 'Event image';
       img.width = 800; img.height = 450;
-      img.onerror = function(){ this.onerror=null; this.src = fallbackImage; };
+      img.onerror = function(){ this.onerror = null; this.src = fallbackImage; };
       media.appendChild(img);
       card.appendChild(media);
 
-      const body = document.createElement("div");
-      body.className = "card-body";
+      const body = document.createElement('div');
+      body.className = 'card-body';
 
-      const h = document.createElement("h3");
-      h.className = "event-title";
-      h.textContent = name || "Untitled Event";
+      const h = document.createElement('h3');
+      h.className = 'event-title';
+      h.textContent = title;
       body.appendChild(h);
 
-      const meta = document.createElement("p");
-      meta.className = "meta";
-      meta.textContent = (date ? date : "") + ((date && time) ? " | " : "") + (time ? time : "");
-      body.appendChild(meta);
+      const start = entry.start ? new Date(entry.start) : null;
+      const dateLabel = start ? formatDate(start, timezone) : '';
+      const timeLabel = start ? formatTime(start, timezone) : '';
 
-      if (locText) {
-        const locP = document.createElement("p");
-        locP.className = "location";
-        locP.textContent = locText;
+      const metaLine = document.createElement('p');
+      metaLine.className = 'meta';
+      metaLine.textContent = [dateLabel, timeLabel].filter(Boolean).join(' | ');
+      body.appendChild(metaLine);
+
+      if (entry.location_warning && entry.raw_location){
+        console.warn('Calendar location mismatch for "%s": "%s"', title, entry.raw_location);
+      }
+
+      const locationText = entry.location_name || 'To be Announced';
+      const locationUrl = entry.location_map_url || '';
+      const hasLocation = Boolean(locationText);
+      const hasTime = Boolean(timeLabel);
+
+      if (hasLocation){
+        const locP = document.createElement('p');
+        locP.className = 'location';
+        if (locationUrl){
+          const link = document.createElement('a');
+          link.href = locationUrl;
+          link.target = '_blank';
+          link.rel = 'noopener';
+          link.setAttribute('data-newtab', 'true');
+          link.textContent = locationText;
+          locP.appendChild(link);
+        } else {
+          locP.textContent = locationText;
+        }
         body.appendChild(locP);
       }
 
-      const mobileInfo = document.createElement("p");
-      mobileInfo.className = "mobile-info";
-      if (locText) mobileInfo.appendChild(document.createTextNode(locText));
-      if (locText && time) mobileInfo.appendChild(document.createTextNode(" | "));
-      if (time) mobileInfo.appendChild(document.createTextNode(time));
-      body.appendChild(mobileInfo);
+      if (hasLocation || hasTime){
+        const mobileInfo = document.createElement('p');
+        mobileInfo.className = 'mobile-info';
+        if (hasLocation){
+          const locSpan = document.createElement('span');
+          locSpan.className = 'mobile-location';
+          locSpan.textContent = locationText;
+          mobileInfo.appendChild(locSpan);
+        }
+        if (hasLocation && hasTime){
+          const sepSpan = document.createElement('span');
+          sepSpan.className = 'mobile-separator';
+          sepSpan.textContent = '|';
+          mobileInfo.appendChild(sepSpan);
+        }
+        if (hasTime){
+          const timeSpan = document.createElement('span');
+          timeSpan.className = 'mobile-time';
+          timeSpan.textContent = timeLabel;
+          mobileInfo.appendChild(timeSpan);
+        }
+        body.appendChild(mobileInfo);
+      }
 
       card.appendChild(body);
 
-      if (eventDateObj) {
-        const dayNum = eventDateObj.getDate();
-        const monthShort = eventDateObj.toLocaleString('en-US', { month: 'short' });
-        const dateBox = document.createElement("div");
-        dateBox.className = "card-date";
-        dateBox.innerHTML =
-          `<div class="day">${String(dayNum).padStart(2,'0')}</div>` +
-          `<div class="month">${monthShort}</div>` +
-          `<div class="time"></div>`;
+      if (start){
+        const dayNum = new Intl.DateTimeFormat('en-US', { day: '2-digit', timeZone: timezone }).format(start);
+        const monthShort = new Intl.DateTimeFormat('en-US', { month: 'short', timeZone: timezone }).format(start);
+        const dateBox = document.createElement('div');
+        dateBox.className = 'card-date';
+        dateBox.innerHTML = `
+          <div class="day">${dayNum}</div>
+          <div class="month">${monthShort}</div>
+          <div class="time"></div>`;
         card.appendChild(dateBox);
       }
 
-      const footer = document.createElement("div");
-      footer.className = "card-footer";
-      if (pageLink) {
-        const btn = document.createElement("a");
-        btn.className = "book-btn";
+      const footer = document.createElement('div');
+      footer.className = 'card-footer';
+      const fallbackLink = slug ? BASEURL + '/events/' + slug + '/' : '';
+      const pageLink = meta?.url || (entry.page_url || fallbackLink);
+      if (pageLink){
+        const btn = document.createElement('a');
+        btn.className = 'book-btn';
         btn.href = pageLink;
-        btn.textContent = "Details";
-        btn.target = "_self";
+        btn.textContent = 'Details';
+        btn.target = '_self';
         btn.removeAttribute('rel');
         footer.appendChild(btn);
       }
       card.appendChild(footer);
 
-      card.addEventListener('click', function(e) {
+      card.addEventListener('click', function(e){
         if (e.target.closest('a,button')) return;
-        if (window.innerWidth <= 768) {
-          if (pageLink) window.location.href = pageLink;
+        if (window.innerWidth <= 768 && pageLink){
+          window.location.href = pageLink;
         }
       });
 
       replaceSkeletonWithCard(container, idx, card);
     });
 
-    if (items.length === 0) {
+    if (!list.length){
       container.innerHTML = '<p style="color:#bbb">No upcoming events.</p>';
     }
   } catch (err) {
     console.error('Upcoming events error:', err);
-    container.innerHTML = '<p style="color:#f66">Could not load events — check the CSV publish link and CSP settings.</p>';
+    container.innerHTML = '<p style="color:#f66">Could not load events — check the calendar artifact and CSP settings.</p>';
   }
 })();
 </script>

--- a/_includes/events-metadata.json
+++ b/_includes/events-metadata.json
@@ -1,0 +1,16 @@
+{% assign first = true %}[
+{% for event in site.events %}
+  {% unless event.draft or event.published == false %}
+    {% unless first %},
+    {% endunless %}{% assign first = false %}
+    {
+      "slug": {{ event.data.slug | default: event.slug | jsonify }},
+      "title": {{ event.title | jsonify }},
+      "intro": {{ event.intro | default: event.tagline | default: '' | jsonify }},
+      "banner": {{ event.banner | default: event.hero_image | jsonify }},
+      "url": {{ event.url | relative_url | jsonify }},
+      "order": {{ event.card_order | default: event.order | default: forloop.index0 | jsonify }}
+    }
+  {% endunless %}
+{% endfor %}
+]

--- a/_includes/head-event.html
+++ b/_includes/head-event.html
@@ -11,11 +11,10 @@
 {% if page.description %}<meta name="description" content="{{ page.description | escape }}">{% endif %}
 {% if page.og_image %}<meta property="og:image" content="{{ page.og_image | escape }}">{% endif %}
 
-<!-- Google Font + PapaParse -->
+<!-- Google Font -->
 <link href="https://fonts.googleapis.com/css2?family=Comfortaa:wght@400;700&display=swap" rel="stylesheet">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js"></script>
 
-<!-- CSP tuned for events (images, CSV, YouTube) -->
+<!-- CSP tuned for events (images, calendar JSON, YouTube) -->
 <meta http-equiv="Content-Security-Policy"
 content="
   default-src 'self';
@@ -23,7 +22,7 @@ content="
   script-src 'self' https://cdnjs.cloudflare.com 'unsafe-inline';
   style-src  'self' 'unsafe-inline' https://fonts.googleapis.com;
   font-src   https://fonts.gstatic.com data:;
-  connect-src https://docs.google.com https://*.googleusercontent.com;
+  connect-src 'self' https://docs.google.com https://*.googleusercontent.com;
   frame-src   https://www.youtube.com https://player.vimeo.com;
   object-src 'none';
   base-uri 'self';

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,7 +8,7 @@
 <meta name="theme-color" content="#181818" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 
-<!-- CSP: allow inline scripts, PapaParse, Google CSV (incl. redirects) -->
+<!-- CSP: allow inline scripts, PapaParse, Google CSV (incl. redirects), and local calendar JSON -->
 <meta http-equiv="Content-Security-Policy"
 content="
   default-src 'self';
@@ -25,7 +25,8 @@ content="
              'unsafe-inline';
   style-src  'self' 'unsafe-inline' https://fonts.googleapis.com;
   font-src   https://fonts.gstatic.com data:;
-  connect-src https://docs.google.com
+  connect-src 'self'
+              https://docs.google.com
               https://*.googleusercontent.com
               https://*.elfsight.com
               https://*.elfsightcdn.com;
@@ -88,7 +89,7 @@ content="
       backdrop-filter: saturate(180%) blur(14px);
     }
   }
-  
+
   .topbar-left.home-link { color: inherit; text-decoration: none; }
   .topbar-left.home-link:focus-visible { outline: 2px solid var(--accent); outline-offset: 4px; }
 
@@ -163,11 +164,14 @@ content="
     .card,.sk-card{width:90vw;max-width:400px;height:auto;flex-direction:row;align-items:center;gap:8px;padding:calc(10px + 1vw) calc(8px + 1vw);border-radius:12px;cursor:pointer;box-shadow:0 2px 8px rgba(0,0,0,.8);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px)}
     .media,.sk-media{width:18vw;max-width:72px;aspect-ratio:1/1;height:auto;padding-top:0;border-radius:10px;overflow:hidden;flex-shrink:0;background:#111}
     .media img{position:static}
-    .card-body,.sk-body{padding:0;display:flex;flex-direction:column;gap:calc(4px + .3vw);flex:1 1 auto}
+    .card-body,.sk-body{padding:0;display:flex;flex-direction:column;gap:calc(4px + .3vw);flex:1 1 auto;min-width:0}
     .event-title{font-size:calc(13px + 1.5vw) !important;font-weight:900 !important;color:#fff;margin:0}
     .meta,.location{display:none}
-    .mobile-info{display:block;font-size:calc(11px + .7vw);color:var(--muted);margin:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:90vw}
-    .mobile-info a{color:var(--accent);text-decoration:none;font-weight:600}
+    .mobile-info{display:flex;align-items:center;gap:6px;font-size:calc(11px + .7vw);color:var(--muted);margin:0;max-width:90vw}
+    .mobile-info .mobile-location{flex:1 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+    .mobile-info .mobile-separator{flex:0 0 auto}
+    .mobile-info .mobile-time{flex:0 0 auto;white-space:nowrap}
+    .mobile-info a{color:var(--accent);text-decoration:none;font-weight:600;white-space:nowrap}
     .mobile-info a:hover{text-decoration:underline}
     .card-footer{display:none}
     .sk-footer{display:none}
@@ -178,6 +182,7 @@ content="
       border:1.5px solid rgba(255,255,255,.08);
       color:#fff;
     }
+    .card-date{flex:0 0 auto}
     .card-date .day{font-weight:800;font-size:calc(22px + 2vw);line-height:1;color:var(--accent);}
     .card-date .month{font-size:calc(12px + 1vw);line-height:1;color:#fff;}
     .sk-line{height:8px;margin:4px 0}

--- a/_includes/scripts-event-core.html
+++ b/_includes/scripts-event-core.html
@@ -1,10 +1,11 @@
 <script>
 (async function(){
-  const SHEET_URL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vSs9vlFaLhdFNFXvWsBIXlAJu0J5Dj2deY_7SlwAGd9Jk1-djK6xP3rdXim7Co0BJ-pUJueDCYYugew/pub?gid=1356004046&single=true&output=csv";
-
+  const CALENDAR_URL = "{{ site.baseurl | default: '' }}/assets/data/calendar.json";
   const BASEURL = "{{ site.baseurl | default: '' }}";
-  const CLEAN = v => (v==null) ? "" : String(v).trim().replace(/^"|"$/g,'');
-  const stripDomain = p => p.replace(/^https?:\/\/[^/]+/, '');
+  const PAGE_SLUG = {{ page.slug | jsonify }} || '';
+  const CLEAN = v => (v == null) ? "" : String(v).trim();
+
+  function stripDomain(p){ return p.replace(/^https?:\/\/[^/]+/, ''); }
   function stripBaseAndSlash(p){
     let x = stripDomain(p);
     if (BASEURL && x.startsWith(BASEURL)) x = x.slice(BASEURL.length);
@@ -14,39 +15,60 @@
   const pagePath = stripBaseAndSlash(location.pathname || '/');
   const titleFallback = (document.getElementById('eventTitle')?.textContent || '').trim();
 
-  function parseEventDate(str){
-    if (!str) return null;
-    str = str.trim().replace(/^[A-Za-z]{3},?\s*/, '').replace(/’/g,"'").replace(/`/g,"'");
-    const m = str.match(/^(\d{1,2})\s+([A-Za-z]{3})\s+'(\d{2})$/);
-    if (!m) return null;
-    const day = parseInt(m[1],10);
-    const mon = { Jan:0,Feb:1,Mar:2,Apr:3,May:4,Jun:5,Jul:6,Aug:7,Sep:8,Oct:9,Nov:10,Dec:11 }[m[2]];
-    const year = 2000 + parseInt(m[3],10);
-    return new Date(year, mon, day);
+  function normalizeSlug(value){
+    if (!value) return '';
+    return value.toString()
+      .normalize('NFKD')
+      .replace(/[\u0300-\u036f]/g,'')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g,'-')
+      .replace(/^-+|-+$/g,'');
   }
-  function fmtDateOnly(d){
-    const dt = new Date(d);
-    const wk = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][dt.getDay()];
-    const day = String(dt.getDate()).padStart(2,'0');
-    const mon = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'][dt.getMonth()];
-    const yr2 = String(dt.getFullYear()).slice(-2);
-    return `${wk}, ${day} ${mon} '${yr2}`;
+
+  function fmtDateOnly(date, timezone){
+    const parts = new Intl.DateTimeFormat('en-US', {
+      weekday: 'short',
+      day: '2-digit',
+      month: 'short',
+      year: '2-digit',
+      timeZone: timezone
+    }).formatToParts(date).reduce((acc, part) => {
+      if (part.type !== 'literal') acc[part.type] = part.value;
+      return acc;
+    }, {});
+    return `${parts.weekday || ''}, ${parts.day || ''} ${parts.month || ''} '${parts.year || ''}`.trim();
   }
-  function parseTime12h(t){
-    if(!t) return {h:19,m:0};
-    const m = t.match(/^(\d{1,2}):(\d{2})\s*(AM|PM)$/i);
-    if(!m) return {h:19,m:0};
-    let h = parseInt(m[1],10), min = parseInt(m[2],10);
-    const ampm = m[3].toUpperCase();
-    if (ampm==='PM' && h<12) h+=12;
-    if (ampm==='AM' && h===12) h=0;
-    return {h, m:min};
+
+  function fmtTime(date, timezone){
+    const str = new Intl.DateTimeFormat('en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: true,
+      timeZone: timezone
+    }).format(date).replace(/\u202f/g, ' ');
+    return str.toUpperCase();
   }
+
+  function dayKey(date, timezone){
+    return new Intl.DateTimeFormat('en-CA', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      timeZone: timezone
+    }).format(date);
+  }
+
+  function parseStart(entry){
+    if (!entry || !entry.start) return null;
+    const d = new Date(entry.start);
+    return isNaN(d.getTime()) ? null : d;
+  }
+
   function makeICS({title, start, durationHours=3, locationText='', locationUrl='', description=''}){
     const dt = new Date(start);
     const end = new Date(dt.getTime() + durationHours*60*60*1000);
     const pad = n => String(n).padStart(2,'0');
-    const stamp = (x)=> x.getFullYear()+pad(x.getMonth()+1)+pad(x.getDate())+'T'+pad(x.getHours())+pad(x.getMinutes())+pad(x.getSeconds());
+    const stamp = (x)=> x.getUTCFullYear()+pad(x.getUTCMonth()+1)+pad(x.getUTCDate())+'T'+pad(x.getUTCHours())+pad(x.getUTCMinutes())+pad(x.getUTCSeconds())+'Z';
     const loc = locationUrl ? `${locationText} (${locationUrl})` : locationText;
     const lines = [
       'BEGIN:VCALENDAR','VERSION:2.0','PRODID:-//Games Lab//Events//EN','BEGIN:VEVENT',
@@ -57,21 +79,30 @@
     return 'data:text/calendar;charset=utf8,' + encodeURIComponent(lines.join('\r\n'));
   }
 
-  // Fetch sheet + find this event
   let match = null;
-  try{
-    const res = await fetch(SHEET_URL + '&cb=' + Date.now(), { cache:'no-store' });
-    const text = await res.text();
-    const rows = Papa.parse(text, { header:true, skipEmptyLines:true }).data;
-    match = rows.find(r=>{
-      const linkPath = stripBaseAndSlash(CLEAN(r['Page Link']));
-      const name = CLEAN(r['EventName']);
-      if (linkPath && pagePath.endsWith(linkPath)) return true;
-      return (titleFallback && name.toLowerCase() === titleFallback.toLowerCase());
-    });
-  }catch(e){ console.error('Sheet load error', e); }
+  let timezone = 'Asia/Kolkata';
 
-  // Elements
+  try {
+    const res = await fetch(CALENDAR_URL + '?v=' + Date.now(), { cache:'no-store' });
+    if (!res.ok) throw new Error('Calendar fetch failed: ' + res.status);
+    const data = await res.json();
+    const events = Array.isArray(data.events) ? data.events : [];
+    timezone = CLEAN(data.timezone) || timezone;
+
+    const pathSlug = normalizeSlug(pagePath.split('/').filter(Boolean).pop());
+
+    match = events.find(entry => {
+      if (!entry) return false;
+      const entrySlug = normalizeSlug(entry.slug || entry.title);
+      if (PAGE_SLUG && entrySlug === normalizeSlug(PAGE_SLUG)) return true;
+      if (pathSlug && entrySlug === pathSlug) return true;
+      if (titleFallback && entry.title && entry.title.toLowerCase() === titleFallback.toLowerCase()) return true;
+      return false;
+    });
+  } catch (e) {
+    console.error('Calendar load error', e);
+  }
+
   const scHeading = document.getElementById('scheduleHeading');
   const scBlock   = document.getElementById('scheduleBlock');
   const scWhen    = document.getElementById('scWhen');
@@ -82,7 +113,6 @@
   const fabBook   = document.getElementById('fabBook');
   const shareFab  = document.getElementById('shareFab');
 
-  // Microbar parts
   const M = {
     bar: document.getElementById('mobileInfoBar'),
     title: document.getElementById('microTitle'),
@@ -101,7 +131,6 @@
   };
 
   const fallbackTicket = {{ page.ticket_link | jsonify }} || '';
-  let scheduled = false, base = null, timeStr = '', locText = '', locLink = '', ticket = fallbackTicket;
   const dFormat = "{{ page.highlights.format | default: 'Social deduction' | escape }}";
   const dDuration = "{{ page.highlights.duration | default: '3–4 hours' | escape }}";
   const dGroup = "{{ page.highlights.group_size | default: '8–25 players' | escape }}";
@@ -143,72 +172,74 @@
     docEl.style.setProperty('--mobile-bottom-pad', pad + 'px');
   }
 
-  if (match){
-    scheduled = CLEAN(match['Scheduled']).toLowerCase() === 'yes';
-    const dateStr = CLEAN(match['Date']);
-    timeStr = CLEAN(match['Time']);
-    locText = CLEAN(match['Location']);
-    locLink = CLEAN(match['Location Link']);
-    const sheetTicket = CLEAN(match['Ticket Link']);
-    if (sheetTicket) ticket = sheetTicket;
-    base = parseEventDate(dateStr);
-    if (base){
-      const tm = parseTime12h(timeStr);
-      base.setHours(tm.h, tm.m, 0, 0);
-    }
+  const scheduleDate = parseStart(match);
+  const todayKey = dayKey(new Date(), timezone);
+  const eventDayKey = scheduleDate ? dayKey(scheduleDate, timezone) : '';
+  const isUpcoming = Boolean(scheduleDate) && eventDayKey >= todayKey;
+
+  if (match?.location_warning && match.raw_location){
+    console.warn('Calendar location mismatch for "%s": "%s"', titleFallback, match.raw_location);
   }
 
-  // Wire schedule (desktop) + FAB
-  if (scheduled && base){
+  const locationText = match?.location_name || 'To be Announced';
+  const locationUrl = match?.location_map_url || '';
+  const timeStr = scheduleDate ? fmtTime(scheduleDate, timezone) : '';
+  const whenText = scheduleDate ? fmtDateOnly(scheduleDate, timezone) : '';
+  const ticket = fallbackTicket;
+
+  if (M.title) M.title.textContent = titleFallback;
+
+  if (isUpcoming && scheduleDate){
     scHeading && scHeading.removeAttribute('hidden');
     if (scBlock) scBlock.hidden = false;
-    scWhen && (scWhen.textContent = fmtDateOnly(base));
-    scWhere && (scWhere.textContent = locText || '');
-    if (scAdd) scAdd.href = makeICS({ title: titleFallback, start: base, durationHours: 3, locationText: locText, locationUrl: locLink, description: location.href });
-    if (scDir && locLink){ scDir.href = locLink; }
+    scWhen && (scWhen.textContent = whenText);
+    scWhere && (scWhere.textContent = locationText || '');
+    if (scAdd) scAdd.href = makeICS({ title: titleFallback, start: scheduleDate, durationHours: 3, locationText, locationUrl, description: location.href });
+    if (scDir){
+      if (locationUrl){
+        scDir.href = locationUrl;
+        scDir.removeAttribute('hidden');
+      } else {
+        scDir.setAttribute('hidden','');
+        scDir.removeAttribute('href');
+      }
+    }
     if (ticket){
-      scBook && (scBook.href = ticket);
+      if (scBook) scBook.href = ticket;
       if (fabBook){
         fabBook.href = ticket;
         fabBook.removeAttribute('hidden');
       }
       requestAnimationFrame(updateFabSpacing);
     } else {
-      if (fabBook){ fabBook.setAttribute('hidden', ''); }
+      if (fabBook){ fabBook.setAttribute('hidden',''); }
       updateFabSpacing();
     }
   } else {
-    // Not scheduled
     scHeading && scHeading.setAttribute('hidden','');
     if (scBlock) scBlock.hidden = true;
     if (fabBook){ fabBook.setAttribute('hidden',''); }
     updateFabSpacing();
   }
 
-  // Microbar content + visibility
-  if (M.title) M.title.textContent = titleFallback;
-  if (scheduled && base){
+  if (isUpcoming && scheduleDate){
     assignText(M.R0, '');
-    const timePart = timeStr && timeStr.trim() ? ` | ${timeStr.trim()}` : '';
-    if (M.L1){ M.L1.textContent = fmtDateOnly(base) + timePart; M.line1?.removeAttribute('hidden'); }
+    const timePart = timeStr ? ` | ${timeStr}` : '';
+    if (M.L1){ M.L1.textContent = whenText + timePart; M.line1?.removeAttribute('hidden'); }
     assignText(M.R1, '');
     if (M.A1){
       M.A1.textContent = 'Add to Calendar';
-      M.A1.href = makeICS({ title: titleFallback, start: base, durationHours: 3, locationText: locText, locationUrl: locLink, description: location.href });
+      M.A1.href = makeICS({ title: titleFallback, start: scheduleDate, durationHours: 3, locationText, locationUrl, description: location.href });
       M.A1.hidden = false;
     }
 
-    if (M.L2){ M.L2.textContent = locText || ''; }
-    if (locText){
-      M.line2?.removeAttribute('hidden');
-    } else {
-      M.line2?.setAttribute('hidden','');
-    }
+    if (M.L2){ M.L2.textContent = locationText || ''; }
+    if (locationText){ M.line2?.removeAttribute('hidden'); } else { M.line2?.setAttribute('hidden',''); }
     assignText(M.R2, '');
     if (M.A2){
-      if (locLink){
+      if (locationUrl){
         M.A2.textContent = 'Get Directions';
-        M.A2.href = locLink;
+        M.A2.href = locationUrl;
         M.A2.hidden = false;
       } else {
         M.A2.hidden = true;
@@ -244,7 +275,6 @@
     M.line3?.setAttribute('hidden','');
   }
 
-  // Microbar show when scrolled past banner/title area (mobile only)
   (function(){
     const microbar = M.bar;
     const banner = document.querySelector('.banner');
@@ -268,7 +298,6 @@
   updateFabSpacing();
   window.addEventListener('resize', ()=>{ updateFabSpacing(); });
 
-  // Share handlers
   (function(){
     async function sharePage(){
       const data = { title: document.title, text: document.title, url: location.href };
@@ -280,7 +309,6 @@
     document.getElementById('shareBtnSide')?.addEventListener('click', sharePage);
     shareFab?.addEventListener('click', sharePage);
   })();
-
 })();
 </script>
 

--- a/assets/data/calendar.json
+++ b/assets/data/calendar.json
@@ -1,5 +1,61 @@
 {
-  "generated_at": "1970-01-01T00:00:00Z",
+  "generated_at": "2025-09-29T02:53:33.440Z",
   "timezone": "Asia/Kolkata",
-  "events": []
+  "events": [
+    {
+      "title": "Night of Mafias !",
+      "slug": "night-of-mafias",
+      "start": "2025-10-10T14:00:00Z",
+      "day_key": "2025-10-10",
+      "timezone": "Asia/Kolkata",
+      "location_name": "Dialogues Cafe",
+      "location_map_url": "https://maps.app.goo.gl/iL4GWxFT7PQ13xtCA",
+      "location_warning": false,
+      "raw_location": "Dialogues Cafe\nDialogues\n21, 20th Main Road, KHB Colony, Block 5, Koramangala, Bengaluru, 560095, Karnataka, India"
+    },
+    {
+      "title": "Board Game Night",
+      "slug": "board-game-night",
+      "start": "2025-10-11T14:00:00Z",
+      "day_key": "2025-10-11",
+      "timezone": "Asia/Kolkata",
+      "location_name": "Big Bean Cafe",
+      "location_map_url": "https://maps.app.goo.gl/SN7w4itJnqGMP2Qw9",
+      "location_warning": false,
+      "raw_location": "Big Bean Cafe\n29, 80 Feet Road\nKoramangala, Bengaluru, Karnataka, India"
+    },
+    {
+      "title": "Party Games Night",
+      "slug": "party-games-night",
+      "start": "2025-10-12T14:30:00Z",
+      "day_key": "2025-10-12",
+      "timezone": "Asia/Kolkata",
+      "location_name": "SLAY Coffee",
+      "location_map_url": "https://maps.app.goo.gl/m44qdH19FcHfErqk7",
+      "location_warning": false,
+      "raw_location": "SLAY Coffee\nSLAY Coffee Bar\n2735, 16th Cross Road, Iblur Camp Colony, HSR Layout, Bengaluru, 560102, Karnataka, India"
+    },
+    {
+      "title": "Trivia Takedown",
+      "slug": "trivia-takedown",
+      "start": "2025-10-13T13:30:00Z",
+      "day_key": "2025-10-13",
+      "timezone": "Asia/Kolkata",
+      "location_name": "Cafe Du L'Amour",
+      "location_map_url": "https://maps.app.goo.gl/vh3Pv3Y9UgYhEFuK7",
+      "location_warning": false,
+      "raw_location": "Cafe Du L’Amour\nCafe Du L'Amour\n980, 1st A Cross Road, Green Leaf Layout, Block 4, Koramangala, Bengaluru, 560034, Karnataka, India"
+    },
+    {
+      "title": "Murder Mystery",
+      "slug": "murder-mystery",
+      "start": "2025-10-14T13:30:00Z",
+      "day_key": "2025-10-14",
+      "timezone": "Asia/Kolkata",
+      "location_name": "The Coffee Brewery",
+      "location_map_url": "https://maps.app.goo.gl/8gpKvEDMUzYUwyKv7",
+      "location_warning": false,
+      "raw_location": "The Coffee Brewery\nThe Coffee Brewery\nMahakavi Vemana Rd, Bengaluru, India"
+    }
+  ]
 }

--- a/assets/data/calendar.json
+++ b/assets/data/calendar.json
@@ -1,0 +1,5 @@
+{
+  "generated_at": "1970-01-01T00:00:00Z",
+  "timezone": "Asia/Kolkata",
+  "events": []
+}

--- a/assets/data/calendar.json
+++ b/assets/data/calendar.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2025-09-29T02:53:33.440Z",
+  "generated_at": "2025-09-29T03:09:46.914Z",
   "timezone": "Asia/Kolkata",
   "events": [
     {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "games-lab-website",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build:calendar": "node scripts/fetch-calendar.mjs"
+  }
+}

--- a/scripts/fetch-calendar.mjs
+++ b/scripts/fetch-calendar.mjs
@@ -1,0 +1,304 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, '..');
+const OUTPUT = path.join(ROOT, 'assets', 'data', 'calendar.json');
+const LOCATIONS_PATH = path.join(ROOT, '_data', 'locations.yml');
+
+const DEFAULT_TIMEZONE = 'Asia/Kolkata';
+const DEFAULT_OFFSET = '+05:30';
+const PUBLIC_CALENDAR_URL = 'https://calendar.google.com/calendar/ical/da645a8c3679d92a4f5aa27a0415af79342a316216a0f83f9d299327c1f0b56e%40group.calendar.google.com/public/basic.ics';
+
+function slugify(value) {
+  if (!value) return '';
+  return value
+    .toString()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function unfoldIcs(text) {
+  return text.replace(/\r\n/g, '\n').replace(/\n[ \t]/g, '');
+}
+
+function parseIcsEvents(text) {
+  const events = [];
+  const unfolded = unfoldIcs(text);
+  const chunks = unfolded.split('BEGIN:VEVENT').slice(1);
+  for (const chunk of chunks) {
+    const body = chunk.split('END:VEVENT')[0];
+    const lines = body.split('\n').map(line => line.trim()).filter(Boolean);
+    const props = new Map();
+    for (const line of lines) {
+      const parts = line.split(':');
+      if (parts.length < 2) continue;
+      const value = parts.slice(1).join(':').trim();
+      const [name, ...paramParts] = parts[0].split(';');
+      const key = name.toUpperCase();
+      const params = {};
+      for (const part of paramParts) {
+        const [pKey, pVal] = part.split('=');
+        if (pKey && pVal) params[pKey.toUpperCase()] = pVal;
+      }
+      props.set(key, { value, params });
+    }
+    events.push(props);
+  }
+  return events;
+}
+
+function toIsoString(date) {
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+function offsetForTz(tzid) {
+  if (!tzid) return DEFAULT_OFFSET;
+  const lower = tzid.toLowerCase();
+  if (lower === 'asia/kolkata' || lower === 'asia/calcutta') return '+05:30';
+  return DEFAULT_OFFSET;
+}
+
+function decodeText(value = '') {
+  return value.replace(/\\([nN,;\\])/g, (_, ch) => {
+    switch (ch) {
+      case 'n':
+      case 'N':
+        return String.fromCharCode(10);
+      case ',':
+        return ',';
+      case ';':
+        return ';';
+      case '\\':
+        return '\\';
+      default:
+        return ch;
+    }
+  });
+}
+
+
+function parseDateTime(value, params) {
+  if (!value) return null;
+  const normalized = value.replace(/Z$/, '');
+  const match = normalized.match(/^(\d{4})(\d{2})(\d{2})(?:T?(\d{2})(\d{2})(\d{2})?)?$/);
+  if (!match) return null;
+  const [, y, m, d, hh = '00', mm = '00', ss = '00'] = match;
+  const year = Number(y);
+  const month = Number(m);
+  const day = Number(d);
+  const hour = Number(hh);
+  const minute = Number(mm);
+  const second = Number(ss);
+
+  if (!value.includes('T')) {
+    return null; // all-day events not supported
+  }
+
+  const isUtc = /Z$/.test(value);
+  const offset = isUtc ? '+00:00' : offsetForTz(params?.TZID);
+  const iso = `${year.toString().padStart(4,'0')}-${String(month).padStart(2,'0')}-${String(day).padStart(2,'0')}T${String(hour).padStart(2,'0')}:${String(minute).padStart(2,'0')}:${String(second).padStart(2,'0')}${offset}`;
+  const date = new Date(iso);
+  return isNaN(date.getTime()) ? null : date;
+}
+
+function formatDayKey(date) {
+  return new Intl.DateTimeFormat('en-CA', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    timeZone: DEFAULT_TIMEZONE,
+  }).format(date);
+}
+
+function normalizeLocationKey(value) {
+  return value ? value.replace(/\s+/g, ' ').trim().toLowerCase() : '';
+}
+
+async function loadLocations() {
+  try {
+    const raw = await fs.readFile(LOCATIONS_PATH, 'utf8');
+    const lines = raw.split(/\r?\n/);
+    const entries = [];
+    let current = null;
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      if (/^\s*-/.test(line)) {
+        if (current) entries.push(current);
+        current = {};
+        const rest = line.replace(/^\s*-\s*/, '');
+        if (rest.includes(':')) {
+          const [key, ...valueParts] = rest.split(':');
+          const keyName = key.trim();
+          const value = valueParts.join(':').trim().replace(/^"|"$/g, '');
+          if (keyName) current[keyName] = value;
+        }
+      } else if (/^\s+/.test(line) && current) {
+        const trimmed = line.trim();
+        if (!trimmed.includes(':')) continue;
+        const [key, ...valueParts] = trimmed.split(':');
+        const keyName = key.trim();
+        const value = valueParts.join(':').trim().replace(/^"|"$/g, '');
+        if (keyName) current[keyName] = value;
+      }
+    }
+    if (current) entries.push(current);
+
+    const map = new Map();
+    for (const entry of entries) {
+      if (!entry) continue;
+      const name = (entry.name || '').trim();
+      if (!name) continue;
+      const key = normalizeLocationKey(name);
+      if (!key) continue;
+      map.set(key, {
+        name,
+        map_url: entry.map_url || '',
+      });
+    }
+    return map;
+  } catch (err) {
+    console.warn('Could not read locations.yml:', err.message);
+    return new Map();
+  }
+}
+
+function resolveLocation(decodedLocation, locations) {
+  const trimmed = (decodedLocation || '').trim();
+  if (!trimmed) {
+    return { match: null, warning: false };
+  }
+
+  const candidates = new Set();
+  candidates.add(trimmed);
+
+  const withoutCarriage = trimmed.replace(/\r/g, '');
+  for (const part of withoutCarriage.split(/\n+/)) {
+    const piece = part.trim();
+    if (!piece) continue;
+    candidates.add(piece);
+    const commaPiece = piece.split(',')[0].trim();
+    if (commaPiece && commaPiece.length >= 2) {
+      candidates.add(commaPiece);
+    }
+  }
+
+  const firstComma = withoutCarriage.split(',')[0]?.trim();
+  if (firstComma) {
+    candidates.add(firstComma);
+  }
+
+  for (const candidate of candidates) {
+    const key = normalizeLocationKey(candidate);
+    if (!key) continue;
+    const match = locations.get(key);
+    if (match) {
+      return { match, warning: false };
+    }
+  }
+
+  const haystack = normalizeLocationKey(trimmed);
+  if (haystack) {
+    for (const [key, match] of locations.entries()) {
+      if (haystack.includes(key)) {
+        return { match, warning: false };
+      }
+    }
+  }
+
+  return { match: null, warning: true };
+}
+
+async function fetchIcs(source) {
+  if (!source) {
+    throw new Error('CALENDAR_ICS_URL is not configured.');
+  }
+  if (/^https?:\/\//i.test(source)) {
+    const res = await fetch(source);
+    if (!res.ok) throw new Error(`Failed to download ICS (${res.status})`);
+    return await res.text();
+  }
+  const filePath = path.isAbsolute(source) ? source : path.join(ROOT, source);
+  return await fs.readFile(filePath, 'utf8');
+}
+
+async function main() {
+  const source = process.env.CALENDAR_ICS_URL || process.env.ICS_URL || PUBLIC_CALENDAR_URL;
+  let icsText = '';
+  try {
+    icsText = await fetchIcs(source);
+  } catch (error) {
+    console.error('[calendar] Unable to fetch ICS:', error.message);
+    throw error;
+  }
+
+  const locations = await loadLocations();
+  const todayKey = formatDayKey(new Date());
+  const deduped = new Map();
+
+  for (const props of parseIcsEvents(icsText)) {
+    const status = props.get('STATUS')?.value?.toUpperCase();
+    if (status === 'CANCELLED') continue;
+
+    const summary = (props.get('SUMMARY')?.value || '').trim();
+    if (!summary) continue;
+
+    const start = parseDateTime(props.get('DTSTART')?.value, props.get('DTSTART')?.params);
+    if (!start) continue;
+
+    const dayKey = formatDayKey(start);
+    if (dayKey < todayKey) continue;
+
+    const slug = slugify(summary);
+    const rawLocationValue = props.get('LOCATION')?.value || '';
+    const decodedLocation = decodeText(rawLocationValue);
+    const rawLocation = decodedLocation.trim();
+    const { match: locationMatch, warning: locationWarning } = resolveLocation(rawLocation, locations);
+
+    const event = {
+      title: summary,
+      slug,
+      start: toIsoString(start),
+      day_key: dayKey,
+      timezone: DEFAULT_TIMEZONE,
+      location_name: locationMatch ? locationMatch.name : 'To be Announced',
+      location_map_url: locationMatch ? locationMatch.map_url : '',
+      location_warning: Boolean(rawLocation) && locationWarning,
+      raw_location: rawLocation,
+    };
+
+    const existing = deduped.get(slug);
+    if (!existing || Date.parse(event.start) < Date.parse(existing.start || '')) {
+      deduped.set(slug, event);
+    }
+  }
+
+  const events = Array.from(deduped.values());
+  events.sort((a, b) => {
+    const da = a?.start ? Date.parse(a.start) : NaN;
+    const db = b?.start ? Date.parse(b.start) : NaN;
+    if (Number.isNaN(da)) return 1;
+    if (Number.isNaN(db)) return -1;
+    return da - db;
+  });
+
+  const payload = {
+    generated_at: new Date().toISOString(),
+    timezone: DEFAULT_TIMEZONE,
+    events,
+  };
+
+  await fs.mkdir(path.dirname(OUTPUT), { recursive: true });
+  await fs.writeFile(OUTPUT, JSON.stringify(payload, null, 2) + '\n');
+  console.log(`[calendar] Wrote ${events.length} upcoming event${events.length === 1 ? '' : 's'} to ${path.relative(ROOT, OUTPUT)}`);
+}
+
+main().catch(err => {
+  console.error('[calendar] Unhandled error:', err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- keep upcoming-card mobile rows readable by splitting location and time spans and linking mapped venues when available
- adjust mobile card flex styling so the date badge stays fixed while long locations ellipsis without truncating the time

## Testing
- CALENDAR_ICS_URL=/tmp/sample.ics npm run build:calendar

------
https://chatgpt.com/codex/tasks/task_e_68d936c621ec832c9b46e6a033d59374