### PR TITLE
Fix mobile upcoming cards layout

### DIFF
--- a/_includes/cards-upcoming.html
+++ b/_includes/cards-upcoming.html
@@ -98,7 +98,7 @@
 
       const originalSize = parseFloat(window.getComputedStyle(title).fontSize) || 16;
       let size = originalSize;
-      const minSize = 12;
+      const minSize = 11;
       const maxIterations = 12;
       title.style.setProperty('--mobile-title-size', `${size}px`);
 
@@ -177,19 +177,16 @@
         const locP = document.createElement('p');
         locP.className = 'location';
         locP.textContent = locationText;
+        locP.title = locationText;
         body.appendChild(locP);
       }
 
-      const mobileInfo = document.createElement('p');
-      mobileInfo.className = 'mobile-info';
-      const infoParts = [];
-      if (timeLabel) infoParts.push(timeLabel);
-      if (locationText) infoParts.push(locationText);
-      const infoText = infoParts.join(' | ');
-      if (infoText){
-        mobileInfo.textContent = infoText;
-        mobileInfo.title = infoText;
-        body.appendChild(mobileInfo);
+      if (timeLabel){
+        const timeP = document.createElement('p');
+        timeP.className = 'time-line';
+        timeP.textContent = timeLabel;
+        timeP.title = timeLabel;
+        body.appendChild(timeP);
       }
 
       details.appendChild(body);
@@ -201,8 +198,7 @@
         dateBox.className = 'card-date';
         dateBox.innerHTML = `
           <div class="day">${dayNum}</div>
-          <div class="month">${monthShort}</div>
-          <div class="time">${timeLabel || ''}</div>`;
+          <div class="month">${monthShort}</div>`;
         details.appendChild(dateBox);
       }
 

--- a/_includes/cards-upcoming.html
+++ b/_includes/cards-upcoming.html
@@ -103,6 +103,9 @@
       media.appendChild(img);
       card.appendChild(media);
 
+      const details = document.createElement('div');
+      details.className = 'card-details';
+
       const body = document.createElement('div');
       body.className = 'card-body';
 
@@ -134,12 +137,17 @@
 
       const mobileInfo = document.createElement('p');
       mobileInfo.className = 'mobile-info';
-      if (timeLabel) mobileInfo.appendChild(document.createTextNode(timeLabel));
-      if (timeLabel && locationText) mobileInfo.appendChild(document.createTextNode(' | '));
-      if (locationText) mobileInfo.appendChild(document.createTextNode(locationText));
-      body.appendChild(mobileInfo);
+      const infoParts = [];
+      if (timeLabel) infoParts.push(timeLabel);
+      if (locationText) infoParts.push(locationText);
+      const infoText = infoParts.join(' | ');
+      if (infoText){
+        mobileInfo.textContent = infoText;
+        mobileInfo.title = infoText;
+        body.appendChild(mobileInfo);
+      }
 
-      card.appendChild(body);
+      details.appendChild(body);
 
       if (start){
         const dayNum = new Intl.DateTimeFormat('en-US', { day: '2-digit', timeZone: timezone }).format(start);
@@ -150,8 +158,10 @@
           <div class="day">${dayNum}</div>
           <div class="month">${monthShort}</div>
           <div class="time"></div>`;
-        card.appendChild(dateBox);
+        details.appendChild(dateBox);
       }
+
+      card.appendChild(details);
 
       const footer = document.createElement('div');
       footer.className = 'card-footer';

--- a/_includes/cards-upcoming.html
+++ b/_includes/cards-upcoming.html
@@ -134,9 +134,9 @@
 
       const mobileInfo = document.createElement('p');
       mobileInfo.className = 'mobile-info';
-      if (locationText) mobileInfo.appendChild(document.createTextNode(locationText));
-      if (locationText && timeLabel) mobileInfo.appendChild(document.createTextNode(' | '));
       if (timeLabel) mobileInfo.appendChild(document.createTextNode(timeLabel));
+      if (timeLabel && locationText) mobileInfo.appendChild(document.createTextNode(' | '));
+      if (locationText) mobileInfo.appendChild(document.createTextNode(locationText));
       body.appendChild(mobileInfo);
 
       card.appendChild(body);

--- a/_includes/cards-upcoming.html
+++ b/_includes/cards-upcoming.html
@@ -243,6 +243,15 @@
         body.appendChild(timeP);
       }
 
+      const mobileInfoText = [timeLabel, locationText].filter(Boolean).join(' | ');
+      if (mobileInfoText){
+        const mobileInfo = document.createElement('p');
+        mobileInfo.className = 'mobile-info';
+        mobileInfo.textContent = mobileInfoText;
+        mobileInfo.title = mobileInfoText;
+        body.appendChild(mobileInfo);
+      }
+
       details.appendChild(body);
 
       if (start){

--- a/_includes/cards-upcoming.html
+++ b/_includes/cards-upcoming.html
@@ -83,48 +83,66 @@
 
     if (list.length > 0) setSkeletons(container, list.length);
 
-    const cardsForTitleFit = new Set();
+    const titleCards = new Set();
 
-    function fitMobileTitle(card){
-      if (!card) return;
-      const title = card.querySelector('.event-title');
-      if (!title) return;
-
+    function recomputeMobileTitleSize(){
       const isMobile = window.matchMedia('(max-width: 768px)').matches;
       if (!isMobile){
-        title.style.removeProperty('--mobile-title-size');
+        container.style.removeProperty('--mobile-title-size');
+        titleCards.forEach(card => {
+          const title = card.querySelector('.event-title');
+          if (title) title.style.removeProperty('--mobile-title-size');
+        });
         return;
       }
 
-      const originalSize = parseFloat(window.getComputedStyle(title).fontSize) || 16;
-      let size = originalSize;
+      container.style.removeProperty('--mobile-title-size');
+
+      let targetSize = Infinity;
       const minSize = 11;
-      const maxIterations = 12;
-      title.style.setProperty('--mobile-title-size', `${size}px`);
+      const maxIterations = 20;
 
-      let iterations = 0;
-      while (title.scrollWidth > title.clientWidth + 0.5 && size > minSize && iterations < maxIterations){
-        size -= 0.5;
+      titleCards.forEach(card => {
+        const title = card.querySelector('.event-title');
+        if (!title) return;
+
+        title.style.removeProperty('--mobile-title-size');
+        const computedSize = parseFloat(window.getComputedStyle(title).fontSize) || 16;
+        let size = computedSize;
+        let iterations = 0;
+
         title.style.setProperty('--mobile-title-size', `${size}px`);
-        iterations++;
-      }
 
-      if (title.scrollWidth > title.clientWidth + 0.5){
-        title.style.setProperty('--mobile-title-size', `${Math.max(size, minSize)}px`);
+        while (title.scrollWidth > title.clientWidth + 0.5 && size > minSize && iterations < maxIterations){
+          size -= 0.5;
+          title.style.setProperty('--mobile-title-size', `${size}px`);
+          iterations++;
+        }
+
+        if (title.scrollWidth > title.clientWidth + 0.5){
+          size = Math.max(size, minSize);
+        }
+
+        targetSize = Math.min(targetSize, size);
+        title.style.removeProperty('--mobile-title-size');
+      });
+
+      if (targetSize !== Infinity){
+        container.style.setProperty('--mobile-title-size', `${targetSize}px`);
       }
     }
 
     function scheduleTitleFit(card){
       if (!card) return;
-      cardsForTitleFit.add(card);
-      requestAnimationFrame(() => fitMobileTitle(card));
+      titleCards.add(card);
+      requestAnimationFrame(() => recomputeMobileTitleSize());
     }
 
     let resizeFrame;
     window.addEventListener('resize', () => {
       if (resizeFrame) cancelAnimationFrame(resizeFrame);
       resizeFrame = requestAnimationFrame(() => {
-        cardsForTitleFit.forEach(card => fitMobileTitle(card));
+        recomputeMobileTitleSize();
       });
     });
 
@@ -229,6 +247,8 @@
       replaceSkeletonWithCard(container, idx, card);
       scheduleTitleFit(card);
     });
+
+    requestAnimationFrame(() => recomputeMobileTitleSize());
 
     if (!list.length){
       container.innerHTML = '<p style="color:#bbb">No upcoming events.</p>';

--- a/_includes/cards-upcoming.html
+++ b/_includes/cards-upcoming.html
@@ -137,10 +137,7 @@
 
       const mobileInfo = document.createElement('p');
       mobileInfo.className = 'mobile-info';
-      const infoParts = [];
-      if (timeLabel) infoParts.push(timeLabel);
-      if (locationText) infoParts.push(locationText);
-      const infoText = infoParts.join(' | ');
+      const infoText = locationText || '';
       if (infoText){
         mobileInfo.textContent = infoText;
         mobileInfo.title = infoText;
@@ -157,7 +154,7 @@
         dateBox.innerHTML = `
           <div class="day">${dayNum}</div>
           <div class="month">${monthShort}</div>
-          <div class="time"></div>`;
+          <div class="time">${timeLabel || ''}</div>`;
         details.appendChild(dateBox);
       }
 

--- a/_includes/cards-upcoming.html
+++ b/_includes/cards-upcoming.html
@@ -83,39 +83,50 @@
 
     if (list.length > 0) setSkeletons(container, list.length);
 
-    const titleCards = new Set();
+    const titleNodes = new Set();
+    const mobileQuery = window.matchMedia('(max-width: 768px)');
+    let recomputeQueued = false;
+
+    function clearMobileSizing(){
+      const root = document.documentElement;
+      root.style.removeProperty('--mobile-title-size');
+      container.style.removeProperty('--mobile-title-size');
+      titleNodes.forEach(title => {
+        if (!title) return;
+        title.style.removeProperty('--mobile-title-size');
+        title.style.removeProperty('font-size');
+      });
+    }
 
     function recomputeMobileTitleSize(){
-      const isMobile = window.matchMedia('(max-width: 768px)').matches;
-      if (!isMobile){
-        container.style.removeProperty('--mobile-title-size');
-        titleCards.forEach(card => {
-          const title = card.querySelector('.event-title');
-          if (title) title.style.removeProperty('--mobile-title-size');
-        });
+      const root = document.documentElement;
+      if (!mobileQuery.matches){
+        clearMobileSizing();
         return;
       }
 
-      container.style.removeProperty('--mobile-title-size');
-
       let targetSize = Infinity;
       const minSize = 11;
-      const maxIterations = 20;
+      const maxIterations = 40;
 
-      titleCards.forEach(card => {
-        const title = card.querySelector('.event-title');
-        if (!title) return;
-
+      titleNodes.forEach(title => {
+        if (!title?.isConnected) return;
         title.style.removeProperty('--mobile-title-size');
+        title.style.removeProperty('font-size');
+      });
+
+      titleNodes.forEach(title => {
+        if (!title?.isConnected) return;
+
         const computedSize = parseFloat(window.getComputedStyle(title).fontSize) || 16;
         let size = computedSize;
         let iterations = 0;
 
-        title.style.setProperty('--mobile-title-size', `${size}px`);
-
         while (title.scrollWidth > title.clientWidth + 0.5 && size > minSize && iterations < maxIterations){
           size -= 0.5;
-          title.style.setProperty('--mobile-title-size', `${size}px`);
+          title.style.setProperty('font-size', `${size}px`, 'important');
+          // Force layout so Safari recalculates scrollWidth before the next iteration.
+          void title.offsetWidth;
           iterations++;
         }
 
@@ -124,27 +135,52 @@
         }
 
         targetSize = Math.min(targetSize, size);
-        title.style.removeProperty('--mobile-title-size');
+        title.style.removeProperty('font-size');
       });
 
-      if (targetSize !== Infinity){
-        container.style.setProperty('--mobile-title-size', `${targetSize}px`);
-      }
+      if (targetSize === Infinity) return;
+
+      const value = `${targetSize}px`;
+      root.style.setProperty('--mobile-title-size', value);
+      container.style.setProperty('--mobile-title-size', value);
+      titleNodes.forEach(title => {
+        if (!title?.isConnected) return;
+        title.style.setProperty('--mobile-title-size', value);
+        title.style.setProperty('font-size', value, 'important');
+      });
     }
 
-    function scheduleTitleFit(card){
-      if (!card) return;
-      titleCards.add(card);
-      requestAnimationFrame(() => recomputeMobileTitleSize());
-    }
-
-    let resizeFrame;
-    window.addEventListener('resize', () => {
-      if (resizeFrame) cancelAnimationFrame(resizeFrame);
-      resizeFrame = requestAnimationFrame(() => {
+    function queueMobileTitleFit(){
+      if (recomputeQueued) return;
+      recomputeQueued = true;
+      requestAnimationFrame(() => {
+        recomputeQueued = false;
         recomputeMobileTitleSize();
       });
-    });
+    }
+
+    function registerTitle(title){
+      if (!title) return;
+      titleNodes.add(title);
+      queueMobileTitleFit();
+    }
+
+    window.addEventListener('resize', queueMobileTitleFit);
+    window.addEventListener('pageshow', queueMobileTitleFit);
+    if (typeof mobileQuery.addEventListener === 'function'){
+      mobileQuery.addEventListener('change', queueMobileTitleFit);
+    } else if (typeof mobileQuery.addListener === 'function'){
+      mobileQuery.addListener(queueMobileTitleFit);
+    }
+
+    if (document.fonts && document.fonts.ready){
+      document.fonts.ready.then(() => queueMobileTitleFit());
+    }
+
+    if ('ResizeObserver' in window){
+      const observer = new ResizeObserver(() => queueMobileTitleFit());
+      observer.observe(container);
+    }
 
     list.forEach((entry, idx) => {
       if (!entry) return;
@@ -245,10 +281,10 @@
       });
 
       replaceSkeletonWithCard(container, idx, card);
-      scheduleTitleFit(card);
+      registerTitle(h);
     });
 
-    requestAnimationFrame(() => recomputeMobileTitleSize());
+    queueMobileTitleFit();
 
     if (!list.length){
       container.innerHTML = '<p style="color:#bbb">No upcoming events.</p>';

--- a/_includes/cards-upcoming.html
+++ b/_includes/cards-upcoming.html
@@ -83,6 +83,51 @@
 
     if (list.length > 0) setSkeletons(container, list.length);
 
+    const cardsForTitleFit = new Set();
+
+    function fitMobileTitle(card){
+      if (!card) return;
+      const title = card.querySelector('.event-title');
+      if (!title) return;
+
+      const isMobile = window.matchMedia('(max-width: 768px)').matches;
+      if (!isMobile){
+        title.style.removeProperty('--mobile-title-size');
+        return;
+      }
+
+      const originalSize = parseFloat(window.getComputedStyle(title).fontSize) || 16;
+      let size = originalSize;
+      const minSize = 12;
+      const maxIterations = 12;
+      title.style.setProperty('--mobile-title-size', `${size}px`);
+
+      let iterations = 0;
+      while (title.scrollWidth > title.clientWidth + 0.5 && size > minSize && iterations < maxIterations){
+        size -= 0.5;
+        title.style.setProperty('--mobile-title-size', `${size}px`);
+        iterations++;
+      }
+
+      if (title.scrollWidth > title.clientWidth + 0.5){
+        title.style.setProperty('--mobile-title-size', `${Math.max(size, minSize)}px`);
+      }
+    }
+
+    function scheduleTitleFit(card){
+      if (!card) return;
+      cardsForTitleFit.add(card);
+      requestAnimationFrame(() => fitMobileTitle(card));
+    }
+
+    let resizeFrame;
+    window.addEventListener('resize', () => {
+      if (resizeFrame) cancelAnimationFrame(resizeFrame);
+      resizeFrame = requestAnimationFrame(() => {
+        cardsForTitleFit.forEach(card => fitMobileTitle(card));
+      });
+    });
+
     list.forEach((entry, idx) => {
       if (!entry) return;
       const slug = normalizeSlug(entry.slug || entry.title);
@@ -137,7 +182,10 @@
 
       const mobileInfo = document.createElement('p');
       mobileInfo.className = 'mobile-info';
-      const infoText = locationText || '';
+      const infoParts = [];
+      if (timeLabel) infoParts.push(timeLabel);
+      if (locationText) infoParts.push(locationText);
+      const infoText = infoParts.join(' | ');
       if (infoText){
         mobileInfo.textContent = infoText;
         mobileInfo.title = infoText;
@@ -183,6 +231,7 @@
       });
 
       replaceSkeletonWithCard(container, idx, card);
+      scheduleTitleFit(card);
     });
 
     if (!list.length){

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -135,6 +135,7 @@ content="
   .card:hover{transform:translateY(-6px);box-shadow:0 10px 28px rgba(0,0,0,.9)}
   .media{width:100%;padding-top:56.25%;position:relative;background:#111}
   .media img{position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover}
+  .card-details{display:flex;flex-direction:column;flex:1 1 auto;width:100%}
   .card-body{padding:14px;display:flex;flex-direction:column;gap:6px}
   .event-title{margin:0;font-size:17px;font-weight:700;color:#fff;line-height:1.18}
   .meta{margin:0;font-size:13.5px;color:var(--muted)}
@@ -164,7 +165,8 @@ content="
     .card,.sk-card{width:90vw;max-width:400px;height:auto;flex-direction:row;align-items:center;gap:8px;padding:calc(10px + 1vw) calc(8px + 1vw);border-radius:12px;cursor:pointer;box-shadow:0 2px 8px rgba(0,0,0,.8);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px)}
     .media,.sk-media{width:18vw;max-width:72px;aspect-ratio:1/1;height:auto;padding-top:0;border-radius:10px;overflow:hidden;flex-shrink:0;background:#111}
     .media img{position:static}
-    .card-body,.sk-body{padding:0;display:flex;flex-direction:column;gap:calc(4px + .3vw);flex:1 1 auto}
+    .card-details{flex:1 1 auto;display:flex;flex-direction:row;align-items:center;gap:calc(8px + 1vw)}
+    .card-body,.sk-body{padding:0;display:flex;flex-direction:column;gap:calc(4px + .3vw);flex:1 1 auto;min-width:0}
     .event-title{font-size:calc(13px + 1.5vw) !important;font-weight:900 !important;color:#fff;margin:0}
     .meta,.location{display:none}
     .mobile-info{display:block;font-size:calc(11px + .7vw);color:var(--muted);margin:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -177,17 +177,34 @@ content="
     .card-date{
       --datebox-size:72px;
       display:flex;
+      inline-size:var(--datebox-size);
+      block-size:var(--datebox-size);
       width:var(--datebox-size);
       height:var(--datebox-size);
       flex:0 0 var(--datebox-size);
       margin-left:auto;
-      flex-direction:column; justify-content:center; align-items:center;
-      border-radius:10px; background:var(--datebox);
+      flex-direction:column;
+      justify-content:center;
+      align-items:center;
+      border-radius:10px;
+      background:var(--datebox);
       border:1.5px solid rgba(255,255,255,.08);
       color:#fff;
+      box-sizing:border-box;
     }
-    .card-date .day{font-weight:800;font-size:calc(22px + 2vw);line-height:1;color:var(--accent);}
-    .card-date .month{font-size:calc(12px + 1vw);line-height:1;color:#fff;}
+    .card-date .day{
+      font-weight:800;
+      font-size:27px;
+      line-height:1;
+      color:var(--accent);
+    }
+    .card-date .month{
+      font-size:16px;
+      line-height:1;
+      color:#fff;
+      text-transform:uppercase;
+      letter-spacing:.5px;
+    }
     .sk-line{height:8px;margin:4px 0}
   }
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -193,6 +193,15 @@ content="
       color:#fff;
       box-sizing:border-box;
     }
+    .card-date .time{
+      margin-top:4px;
+      font-size:calc(10px + .5vw);
+      font-weight:600;
+      color:var(--muted);
+      letter-spacing:.3px;
+      text-transform:uppercase;
+      line-height:1.05;
+    }
     .card-date .day{
       font-weight:800;
       font-size:27px;

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -167,13 +167,17 @@ content="
     .card-body,.sk-body{padding:0;display:flex;flex-direction:column;gap:calc(4px + .3vw);flex:1 1 auto}
     .event-title{font-size:calc(13px + 1.5vw) !important;font-weight:900 !important;color:#fff;margin:0}
     .meta,.location{display:none}
-    .mobile-info{display:block;font-size:calc(11px + .7vw);color:var(--muted);margin:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:90vw}
+    .mobile-info{display:block;font-size:calc(11px + .7vw);color:var(--muted);margin:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%}
     .mobile-info a{color:var(--accent);text-decoration:none;font-weight:600}
     .mobile-info a:hover{text-decoration:underline}
     .card-footer{display:none}
     .sk-footer{display:none}
     .card-date{
-      display:flex;width:18vw; max-width:72px;height:auto; aspect-ratio:1/1;
+      --datebox-size:min(18vw,72px);
+      display:flex;
+      width:var(--datebox-size);
+      height:var(--datebox-size);
+      flex:0 0 var(--datebox-size);
       flex-direction:column; justify-content:center; align-items:center;
       border-radius:10px; background:var(--datebox);
       border:1.5px solid rgba(255,255,255,.08);

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -173,11 +173,12 @@ content="
     .card-footer{display:none}
     .sk-footer{display:none}
     .card-date{
-      --datebox-size:min(18vw,72px);
+      --datebox-size:72px;
       display:flex;
       width:var(--datebox-size);
       height:var(--datebox-size);
       flex:0 0 var(--datebox-size);
+      margin-left:auto;
       flex-direction:column; justify-content:center; align-items:center;
       border-radius:10px; background:var(--datebox);
       border:1.5px solid rgba(255,255,255,.08);

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -166,7 +166,14 @@ content="
     .card,.sk-card{width:90vw;max-width:400px;height:auto;flex-direction:row;align-items:center;gap:8px;padding:calc(10px + 1vw) calc(8px + 1vw);border-radius:12px;cursor:pointer;box-shadow:0 2px 8px rgba(0,0,0,.8);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px)}
     .media,.sk-media{width:18vw;max-width:72px;aspect-ratio:1/1;height:auto;padding-top:0;border-radius:10px;overflow:hidden;flex-shrink:0;background:#111}
     .media img{position:static}
-    .card-details{flex:1 1 auto;display:grid;grid-template-columns:minmax(0,1fr) auto;align-items:center;column-gap:calc(8px + 1vw)}
+    .card-details{
+      --datebox-size:72px;
+      flex:1 1 auto;
+      display:grid;
+      grid-template-columns:minmax(0,1fr) var(--datebox-size);
+      align-items:center;
+      column-gap:calc(8px + 1vw);
+    }
     .card-body,.sk-body{padding:0;display:flex;flex-direction:column;gap:calc(4px + .3vw);flex:1 1 auto;min-width:0}
     .event-title{
       font-size:var(--mobile-title-size, calc(13px + 1.5vw)) !important;
@@ -178,8 +185,18 @@ content="
       text-overflow:ellipsis;
     }
     .meta{display:none}
-    .location{display:block;font-size:calc(11px + .7vw);color:var(--muted);margin:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%}
-    .time-line{display:block;font-size:calc(11px + .7vw);color:var(--muted);margin:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%}
+    .location{display:none}
+    .time-line{display:none}
+    .mobile-info{
+      display:block;
+      font-size:calc(11px + .7vw);
+      color:var(--muted);
+      margin:0;
+      white-space:nowrap;
+      overflow:hidden;
+      text-overflow:ellipsis;
+      max-width:100%;
+    }
     .card-footer{display:none}
     .sk-footer{display:none}
     .card-date{

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -167,7 +167,7 @@ content="
     .media img{position:static}
     .card-details{flex:1 1 auto;display:grid;grid-template-columns:minmax(0,1fr) auto;align-items:center;column-gap:calc(8px + 1vw)}
     .card-body,.sk-body{padding:0;display:flex;flex-direction:column;gap:calc(4px + .3vw);flex:1 1 auto;min-width:0}
-    .event-title{font-size:calc(13px + 1.5vw) !important;font-weight:900 !important;color:#fff;margin:0}
+    .event-title{font-size:var(--mobile-title-size, calc(13px + 1.5vw)) !important;font-weight:900 !important;color:#fff;margin:0}
     .meta,.location{display:none}
     .mobile-info{display:block;font-size:calc(11px + .7vw);color:var(--muted);margin:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%}
     .mobile-info a{color:var(--accent);text-decoration:none;font-weight:600}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -165,7 +165,7 @@ content="
     .card,.sk-card{width:90vw;max-width:400px;height:auto;flex-direction:row;align-items:center;gap:8px;padding:calc(10px + 1vw) calc(8px + 1vw);border-radius:12px;cursor:pointer;box-shadow:0 2px 8px rgba(0,0,0,.8);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px)}
     .media,.sk-media{width:18vw;max-width:72px;aspect-ratio:1/1;height:auto;padding-top:0;border-radius:10px;overflow:hidden;flex-shrink:0;background:#111}
     .media img{position:static}
-    .card-details{flex:1 1 auto;display:flex;flex-direction:row;align-items:center;gap:calc(8px + 1vw)}
+    .card-details{flex:1 1 auto;display:grid;grid-template-columns:minmax(0,1fr) auto;align-items:center;column-gap:calc(8px + 1vw)}
     .card-body,.sk-body{padding:0;display:flex;flex-direction:column;gap:calc(4px + .3vw);flex:1 1 auto;min-width:0}
     .event-title{font-size:calc(13px + 1.5vw) !important;font-weight:900 !important;color:#fff;margin:0}
     .meta,.location{display:none}
@@ -182,7 +182,8 @@ content="
       width:var(--datebox-size);
       height:var(--datebox-size);
       flex:0 0 var(--datebox-size);
-      margin-left:auto;
+      margin-left:0;
+      justify-self:end;
       flex-direction:column;
       justify-content:center;
       align-items:center;

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -160,6 +160,7 @@ content="
 
   .mobile-info{display:none}
   .card-date{display:none}
+  .time-line{display:none}
   @media (max-width:768px){
     .cards-row{justify-content:center}
     .card,.sk-card{width:90vw;max-width:400px;height:auto;flex-direction:row;align-items:center;gap:8px;padding:calc(10px + 1vw) calc(8px + 1vw);border-radius:12px;cursor:pointer;box-shadow:0 2px 8px rgba(0,0,0,.8);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px)}
@@ -167,11 +168,18 @@ content="
     .media img{position:static}
     .card-details{flex:1 1 auto;display:grid;grid-template-columns:minmax(0,1fr) auto;align-items:center;column-gap:calc(8px + 1vw)}
     .card-body,.sk-body{padding:0;display:flex;flex-direction:column;gap:calc(4px + .3vw);flex:1 1 auto;min-width:0}
-    .event-title{font-size:var(--mobile-title-size, calc(13px + 1.5vw)) !important;font-weight:900 !important;color:#fff;margin:0}
-    .meta,.location{display:none}
-    .mobile-info{display:block;font-size:calc(11px + .7vw);color:var(--muted);margin:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%}
-    .mobile-info a{color:var(--accent);text-decoration:none;font-weight:600}
-    .mobile-info a:hover{text-decoration:underline}
+    .event-title{
+      font-size:var(--mobile-title-size, calc(13px + 1.5vw)) !important;
+      font-weight:900 !important;
+      color:#fff;
+      margin:0;
+      white-space:nowrap;
+      overflow:hidden;
+      text-overflow:ellipsis;
+    }
+    .meta{display:none}
+    .location{display:block;font-size:calc(11px + .7vw);color:var(--muted);margin:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%}
+    .time-line{display:block;font-size:calc(11px + .7vw);color:var(--muted);margin:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%}
     .card-footer{display:none}
     .sk-footer{display:none}
     .card-date{
@@ -192,15 +200,6 @@ content="
       border:1.5px solid rgba(255,255,255,.08);
       color:#fff;
       box-sizing:border-box;
-    }
-    .card-date .time{
-      margin-top:4px;
-      font-size:calc(10px + .5vw);
-      font-weight:600;
-      color:var(--muted);
-      letter-spacing:.3px;
-      text-transform:uppercase;
-      line-height:1.05;
     }
     .card-date .day{
       font-weight:800;


### PR DESCRIPTION
## Summary
- lock the mobile event card date boxes to a consistent square footprint
- reorder the mobile info line to display time before location while retaining truncation

## Testing
- bundle exec jekyll serve *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68d9fa671aec832c84bc9fd2be7572d9