### PR TITLE
Show weekday next to time in mobile upcoming cards

### DIFF
--- a/_includes/cards-upcoming.html
+++ b/_includes/cards-upcoming.html
@@ -66,6 +66,13 @@
     return str.toUpperCase();
   }
 
+  function formatWeekday(date, timezone){
+    return new Intl.DateTimeFormat('en-US', {
+      weekday: 'short',
+      timeZone: timezone
+    }).format(date);
+  }
+
   try{
     const res = await fetch(CALENDAR_URL + '?v=' + Date.now(), { cache: 'no-store' });
     if (!res.ok) throw new Error('Calendar fetch failed: ' + res.status);
@@ -114,6 +121,7 @@
       const start = entry.start ? new Date(entry.start) : null;
       const dateLabel = start ? formatDate(start, timezone) : '';
       const timeLabel = start ? formatTime(start, timezone) : '';
+      const weekdayLabel = start ? formatWeekday(start, timezone) : '';
 
       const metaLine = document.createElement('p');
       metaLine.className = 'meta';
@@ -132,10 +140,10 @@
         body.appendChild(locP);
       }
 
-      if (timeLabel){
+      if (timeLabel || weekdayLabel){
         const timeP = document.createElement('p');
         timeP.className = 'time';
-        timeP.textContent = timeLabel;
+        timeP.textContent = [weekdayLabel, timeLabel].filter(Boolean).join(' | ');
         body.appendChild(timeP);
       }
 


### PR DESCRIPTION
## Summary
- add a weekday formatter for upcoming event cards
- display the weekday alongside the time in the mobile-only row

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da4b3a7588832c937b94544ca8aa94