### PR TITLE
Add mobile "No date yet" CTA and scroll-aware FAB for unscheduled events

### DIFF
--- a/_includes/event-hero.html
+++ b/_includes/event-hero.html
@@ -6,6 +6,17 @@
 <!-- Right card (desktop) -->
 <aside class="side-card" aria-label="Highlights">
   <div class="info-card" role="complementary">
+    {%- comment -%}
+      Unhidden by scripts-event-core.html when this event has no upcoming
+      calendar date. On desktop it occupies the same card as the schedule;
+      the side card remains hidden at the mobile breakpoint for now.
+    {%- endcomment -%}
+    <div class="no-date" id="noDateNotice" hidden>
+      <p class="no-date__text">No date announced for {{ page.title }} yet — new dates go up every few weeks.</p>
+      <a class="book-btn" href="https://wa.me/917676099857?text={{ 'Hi Games Lab! When is the next ' | append: page.title | append: '?' | url_encode }}"
+         target="_blank" rel="noopener">Ask us when it&rsquo;s next</a>
+    </div>
+
     <h3 id="scheduleHeading" hidden>Schedule</h3>
     <!-- schedule block toggled by JS -->
     <div id="scheduleBlock" hidden>
@@ -58,6 +69,9 @@
 
 <!-- Floating FABs (mobile) -->
 <a id="fabBook" class="fab-book" href="#" target="_blank" rel="noopener" hidden>Book Now</a>
+<a id="fabNoDate" class="fab-book fab-no-date"
+   href="https://wa.me/917676099857?text={{ 'Hi Games Lab! When is the next ' | append: page.title | append: '?' | url_encode }}"
+   target="_blank" rel="noopener" hidden>Ask when it&rsquo;s next</a>
 <button id="shareFab" class="fab-share" aria-label="Share this event" title="Share">
   <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
     <path fill="currentColor" d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7a3.27 3.27 0 000-1.39l7.02-4.11A2.99 2.99 0 0018 7.91a3 3 0 10-2.82-4H15a3 3 0 00.04 1.5l-7.02 4.11a3 3 0 10.01 4.96l7.02 4.11A3 3 0 1018 16.09z"/>

--- a/_includes/event-sections.html
+++ b/_includes/event-sections.html
@@ -1,14 +1,4 @@
 <article class="content">
-  {%- comment -%}
-    Unhidden by scripts-event-core.html when the calendar has no upcoming date
-    for this event, so the page never just silently drops the Book Now button.
-  {%- endcomment -%}
-  <div class="no-date" id="noDateNotice" hidden>
-    <p class="no-date__text">No date announced for {{ page.title }} yet — new dates go up every few weeks.</p>
-    <a class="book-btn" href="https://wa.me/917676099857?text={{ 'Hi Games Lab! When is the next ' | append: page.title | append: '?' | url_encode }}"
-       target="_blank" rel="noopener">Ask us when it&rsquo;s next</a>
-  </div>
-
   {% assign about_copy = page.about | default: nil %}
   {% assign has_sections = false %}
 

--- a/_includes/scripts-event-core.html
+++ b/_includes/scripts-event-core.html
@@ -112,6 +112,7 @@
   const scSeats   = document.getElementById('scSeats');
   const scBook    = document.getElementById('scBook');
   const fabBook   = document.getElementById('fabBook');
+  const fabNoDate = document.getElementById('fabNoDate');
   const shareFab  = document.getElementById('shareFab');
   const noDateNotice = document.getElementById('noDateNotice');
 
@@ -164,13 +165,15 @@
     // getClientRects() is empty for a display:none element. Without that check
     // the desktop breakpoint (where .fab-book is display:none but carries no
     // hidden attribute) measures 0 and re-queues itself forever.
-    const bookVisible = fabBook
-      && !fabBook.hasAttribute('hidden')
-      && fabBook.getClientRects().length > 0;
+    const activeFab = [fabBook, fabNoDate].find(el => el
+      && !el.hasAttribute('hidden')
+      && !el.classList.contains('is-scroll-hidden')
+      && el.getClientRects().length > 0);
+    const bookVisible = Boolean(activeFab);
     let bookHeight = 0;
     if (bookVisible){
-      const rect = fabBook.getBoundingClientRect();
-      bookHeight = rect.height || fabBook.offsetHeight || 0;
+      const rect = activeFab.getBoundingClientRect();
+      bookHeight = rect.height || activeFab.offsetHeight || 0;
       if (!bookHeight && fabMeasureRetries < 10){
         fabMeasureRetries += 1;
         requestAnimationFrame(updateFabSpacing);
@@ -256,7 +259,37 @@
     if (scBlock) scBlock.hidden = true;
     if (fabBook){ fabBook.setAttribute('hidden',''); }
     if (noDateNotice) noDateNotice.removeAttribute('hidden');
+    if (fabNoDate) fabNoDate.removeAttribute('hidden');
     updateFabSpacing();
+  }
+
+  // The unscheduled-event CTA is useful on mobile but should not cover the
+  // page while somebody reads downward. Reveal it again as soon as they scroll
+  // upward. Scheduled events continue to use the always-visible Book Now FAB.
+  if (fabNoDate && !isUpcoming){
+    let lastScrollY = Math.max(0, window.scrollY);
+    let scrollTicking = false;
+
+    function updateNoDateFabOnScroll(){
+      const currentY = Math.max(0, window.scrollY);
+      const delta = currentY - lastScrollY;
+
+      if (currentY <= 12 || delta < -4){
+        fabNoDate.classList.remove('is-scroll-hidden');
+      } else if (delta > 4){
+        fabNoDate.classList.add('is-scroll-hidden');
+      }
+
+      lastScrollY = currentY;
+      scrollTicking = false;
+      updateFabSpacing();
+    }
+
+    window.addEventListener('scroll', () => {
+      if (scrollTicking) return;
+      scrollTicking = true;
+      requestAnimationFrame(updateNoDateFabOnScroll);
+    }, { passive:true });
   }
 
   if (isUpcoming && scheduleDate){

--- a/_includes/styles-event.html
+++ b/_includes/styles-event.html
@@ -45,6 +45,7 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
 
 /* "No date yet" notice (event has no upcoming calendar entry) */
 .no-date{display:flex;flex-direction:column;align-items:center;gap:12px;text-align:center;margin:0 0 22px;padding:20px 18px;border-radius:14px;background:var(--card);border:1.5px solid rgba(255,255,255,.08)}
+.no-date[hidden]{display:none}
 .no-date__text{margin:0;font-size:1rem;line-height:1.6;color:var(--muted)}
 @media (prefers-color-scheme: light){.no-date{border-color:rgba(0,0,0,.06);box-shadow:0 6px 22px rgba(0,0,0,.08)}}
 
@@ -223,6 +224,8 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
 .fab-book,.fab-share{position:fixed;z-index:10000;border-radius:999px;box-shadow:0 6px 18px rgba(0,0,0,.35);display:flex;align-items:center;gap:10px;padding:12px 16px;text-decoration:none}
 .fab-book{left:12px;right:12px;bottom:6px;background:var(--accent);color:#000;font-weight:900;justify-content:center;text-align:center}
 .fab-book[hidden]{display:none}
+.fab-no-date{transition:transform .24s ease,opacity .24s ease}
+.fab-no-date.is-scroll-hidden{transform:translateY(calc(100% + 18px));opacity:0;pointer-events:none}
 .fab-share{right:12px;bottom:var(--fab-share-bottom,12px);background:rgba(24,24,24,.35);color:var(--text-main);border:1px solid rgba(255,255,255,.25);-webkit-backdrop-filter:blur(10px);backdrop-filter:blur(10px)}
 .fab-share .fab-share-label{font-weight:900;font-size:.95rem}
 @media (prefers-color-scheme: light){
@@ -230,6 +233,7 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
   .fab-share{background:rgba(255,255,255,.65);border-color:rgba(0,0,0,.15);color:inherit}
 }
 @media (min-width:960px){.fab-book,.fab-share{display:none}}
+@media (prefers-reduced-motion:reduce){.fab-no-date{transition:none}}
 
 .book-drawer{position:fixed;inset:0;z-index:10030}
 .book-drawer[hidden]{display:none}


### PR DESCRIPTION
### Motivation

- Make it easy for users to ask about upcoming dates when an event has no scheduled session by providing a prominent mobile CTA. 
- Prevent the unscheduled CTA from obstructing reading on mobile by hiding it while scrolling down and revealing it when scrolling up.

### Description

- Move the existing `no-date` notice out of the main content into the event hero and add a mobile FAB (`#fabNoDate`) that links to the WhatsApp inquiry for the event. 
- Wire `fabNoDate` into the event JS by adding it to the FAB measurement logic, using an `activeFab` lookup so either the Book or No-Date FAB can be measured and used for spacing. 
- Add a scroll listener that toggles a `.is-scroll-hidden` class on `fabNoDate` to hide the FAB while scrolling down and reveal it when scrolling up. 
- Remove the duplicate `no-date` block from `_includes/event-sections.html` and add supporting CSS rules (`.no-date[hidden]{display:none}`, `.fab-no-date` transitions and `.fab-no-date.is-scroll-hidden` behavior) including a reduced-motion rule.

### Testing

- Built the site with `jekyll build` and confirmed the build completed with no errors. 
- Ran the repository lints via `npm run lint` and observed no lint errors for the updated JS/CSS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c6cfbeaa8832ca5962a1fd4878911)