### PR TITLE
Admin: safe occurrence cancel/hide + dashboard tabs and mobile UX updates; add mobile “no date” CTA

### DIFF
--- a/_includes/event-hero.html
+++ b/_includes/event-hero.html
@@ -6,6 +6,17 @@
 <!-- Right card (desktop) -->
 <aside class="side-card" aria-label="Highlights">
   <div class="info-card" role="complementary">
+    {%- comment -%}
+      Unhidden by scripts-event-core.html when this event has no upcoming
+      calendar date. On desktop it occupies the same card as the schedule;
+      the side card remains hidden at the mobile breakpoint for now.
+    {%- endcomment -%}
+    <div class="no-date" id="noDateNotice" hidden>
+      <p class="no-date__text">No date announced for {{ page.title }} yet — new dates go up every few weeks.</p>
+      <a class="book-btn" href="https://wa.me/917676099857?text={{ 'Hi Games Lab! When is the next ' | append: page.title | append: '?' | url_encode }}"
+         target="_blank" rel="noopener">Ask us when it&rsquo;s next</a>
+    </div>
+
     <h3 id="scheduleHeading" hidden>Schedule</h3>
     <!-- schedule block toggled by JS -->
     <div id="scheduleBlock" hidden>
@@ -58,6 +69,9 @@
 
 <!-- Floating FABs (mobile) -->
 <a id="fabBook" class="fab-book" href="#" target="_blank" rel="noopener" hidden>Book Now</a>
+<a id="fabNoDate" class="fab-book fab-no-date"
+   href="https://wa.me/917676099857?text={{ 'Hi Games Lab! When is the next ' | append: page.title | append: '?' | url_encode }}"
+   target="_blank" rel="noopener" hidden>Ask when it&rsquo;s next</a>
 <button id="shareFab" class="fab-share" aria-label="Share this event" title="Share">
   <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
     <path fill="currentColor" d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7a3.27 3.27 0 000-1.39l7.02-4.11A2.99 2.99 0 0018 7.91a3 3 0 10-2.82-4H15a3 3 0 00.04 1.5l-7.02 4.11a3 3 0 10.01 4.96l7.02 4.11A3 3 0 1018 16.09z"/>

--- a/_includes/event-sections.html
+++ b/_includes/event-sections.html
@@ -1,14 +1,4 @@
 <article class="content">
-  {%- comment -%}
-    Unhidden by scripts-event-core.html when the calendar has no upcoming date
-    for this event, so the page never just silently drops the Book Now button.
-  {%- endcomment -%}
-  <div class="no-date" id="noDateNotice" hidden>
-    <p class="no-date__text">No date announced for {{ page.title }} yet — new dates go up every few weeks.</p>
-    <a class="book-btn" href="https://wa.me/917676099857?text={{ 'Hi Games Lab! When is the next ' | append: page.title | append: '?' | url_encode }}"
-       target="_blank" rel="noopener">Ask us when it&rsquo;s next</a>
-  </div>
-
   {% assign about_copy = page.about | default: nil %}
   {% assign has_sections = false %}
 

--- a/_includes/scripts-event-core.html
+++ b/_includes/scripts-event-core.html
@@ -112,6 +112,7 @@
   const scSeats   = document.getElementById('scSeats');
   const scBook    = document.getElementById('scBook');
   const fabBook   = document.getElementById('fabBook');
+  const fabNoDate = document.getElementById('fabNoDate');
   const shareFab  = document.getElementById('shareFab');
   const noDateNotice = document.getElementById('noDateNotice');
 
@@ -164,13 +165,15 @@
     // getClientRects() is empty for a display:none element. Without that check
     // the desktop breakpoint (where .fab-book is display:none but carries no
     // hidden attribute) measures 0 and re-queues itself forever.
-    const bookVisible = fabBook
-      && !fabBook.hasAttribute('hidden')
-      && fabBook.getClientRects().length > 0;
+    const activeFab = [fabBook, fabNoDate].find(el => el
+      && !el.hasAttribute('hidden')
+      && !el.classList.contains('is-scroll-hidden')
+      && el.getClientRects().length > 0);
+    const bookVisible = Boolean(activeFab);
     let bookHeight = 0;
     if (bookVisible){
-      const rect = fabBook.getBoundingClientRect();
-      bookHeight = rect.height || fabBook.offsetHeight || 0;
+      const rect = activeFab.getBoundingClientRect();
+      bookHeight = rect.height || activeFab.offsetHeight || 0;
       if (!bookHeight && fabMeasureRetries < 10){
         fabMeasureRetries += 1;
         requestAnimationFrame(updateFabSpacing);
@@ -256,7 +259,37 @@
     if (scBlock) scBlock.hidden = true;
     if (fabBook){ fabBook.setAttribute('hidden',''); }
     if (noDateNotice) noDateNotice.removeAttribute('hidden');
+    if (fabNoDate) fabNoDate.removeAttribute('hidden');
     updateFabSpacing();
+  }
+
+  // The unscheduled-event CTA is useful on mobile but should not cover the
+  // page while somebody reads downward. Reveal it again as soon as they scroll
+  // upward. Scheduled events continue to use the always-visible Book Now FAB.
+  if (fabNoDate && !isUpcoming){
+    let lastScrollY = Math.max(0, window.scrollY);
+    let scrollTicking = false;
+
+    function updateNoDateFabOnScroll(){
+      const currentY = Math.max(0, window.scrollY);
+      const delta = currentY - lastScrollY;
+
+      if (currentY <= 12 || delta < -4){
+        fabNoDate.classList.remove('is-scroll-hidden');
+      } else if (delta > 4){
+        fabNoDate.classList.add('is-scroll-hidden');
+      }
+
+      lastScrollY = currentY;
+      scrollTicking = false;
+      updateFabSpacing();
+    }
+
+    window.addEventListener('scroll', () => {
+      if (scrollTicking) return;
+      scrollTicking = true;
+      requestAnimationFrame(updateNoDateFabOnScroll);
+    }, { passive:true });
   }
 
   if (isUpcoming && scheduleDate){

--- a/_includes/styles-event.html
+++ b/_includes/styles-event.html
@@ -45,6 +45,7 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
 
 /* "No date yet" notice (event has no upcoming calendar entry) */
 .no-date{display:flex;flex-direction:column;align-items:center;gap:12px;text-align:center;margin:0 0 22px;padding:20px 18px;border-radius:14px;background:var(--card);border:1.5px solid rgba(255,255,255,.08)}
+.no-date[hidden]{display:none}
 .no-date__text{margin:0;font-size:1rem;line-height:1.6;color:var(--muted)}
 @media (prefers-color-scheme: light){.no-date{border-color:rgba(0,0,0,.06);box-shadow:0 6px 22px rgba(0,0,0,.08)}}
 
@@ -223,6 +224,8 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
 .fab-book,.fab-share{position:fixed;z-index:10000;border-radius:999px;box-shadow:0 6px 18px rgba(0,0,0,.35);display:flex;align-items:center;gap:10px;padding:12px 16px;text-decoration:none}
 .fab-book{left:12px;right:12px;bottom:6px;background:var(--accent);color:#000;font-weight:900;justify-content:center;text-align:center}
 .fab-book[hidden]{display:none}
+.fab-no-date{transition:transform .24s ease,opacity .24s ease}
+.fab-no-date.is-scroll-hidden{transform:translateY(calc(100% + 18px));opacity:0;pointer-events:none}
 .fab-share{right:12px;bottom:var(--fab-share-bottom,12px);background:rgba(24,24,24,.35);color:var(--text-main);border:1px solid rgba(255,255,255,.25);-webkit-backdrop-filter:blur(10px);backdrop-filter:blur(10px)}
 .fab-share .fab-share-label{font-weight:900;font-size:.95rem}
 @media (prefers-color-scheme: light){
@@ -230,6 +233,13 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
   .fab-share{background:rgba(255,255,255,.65);border-color:rgba(0,0,0,.15);color:inherit}
 }
 @media (min-width:960px){.fab-book,.fab-share{display:none}}
+@media (prefers-reduced-motion:reduce){.fab-no-date{transition:none}}
+
+/* Override the slide-out treatment without editing its shared definition.
+   Moving a fixed element below the viewport paints its accent background into
+   iOS Safari's bottom safe area; fading in place avoids that browser artifact. */
+.fab-no-date{transition:opacity .2s ease,visibility 0s linear .2s}
+.fab-no-date.is-scroll-hidden{transform:none;opacity:0;visibility:hidden;pointer-events:none}
 
 .book-drawer{position:fixed;inset:0;z-index:10030}
 .book-drawer[hidden]{display:none}

--- a/admin.html
+++ b/admin.html
@@ -63,6 +63,9 @@ robots: noindex, nofollow
     .desk-tools .book-btn { padding: 8px 15px; font-size: 14px; }
 
     .desk-cards { display: grid; gap: 12px; }
+    .desk-tabs { display: flex; gap: 6px; margin: 0 0 16px; padding: 4px; border-radius: 12px; background: var(--card); }
+    .desk-tab { flex: 1; border: 0; border-radius: 9px; padding: 9px 8px; background: transparent; color: var(--muted); font: inherit; font-size: 13px; font-weight: 700; cursor: pointer; }
+    .desk-tab[aria-selected="true"] { background: var(--accent); color: #000; }
 
     .occ {
       background: var(--card);
@@ -93,6 +96,12 @@ robots: noindex, nofollow
     .pill--warn { background: color-mix(in srgb, #ff8a5c 30%, transparent); }
 
     .occ__actions { display: flex; flex-wrap: wrap; gap: 8px; }
+    .occ__menu { position: relative; margin-left: auto; }
+    .occ__menu summary { width: 40px; height: 40px; display: grid; place-items: center; border-radius: 999px; cursor: pointer; list-style: none; font-size: 22px; border: 1px solid color-mix(in srgb, var(--muted) 30%, transparent); }
+    .occ__menu summary::-webkit-details-marker { display: none; }
+    .occ__menu-panel { position: absolute; right: 0; bottom: calc(100% + 6px); z-index: 5; min-width: 190px; padding: 6px; border-radius: 10px; background: var(--card); box-shadow: 0 10px 30px rgba(0,0,0,.5); }
+    .occ__menu-panel button { width: 100%; border: 0; border-radius: 8px; padding: 10px; text-align: left; background: transparent; color: #ff9b78; font: inherit; cursor: pointer; }
+    .occ__menu-panel button:hover { background: color-mix(in srgb, var(--muted) 16%, transparent); }
 
     .att { margin: 0; border-collapse: collapse; width: 100%; font-size: 13.5px; }
     .att th, .att td { text-align: left; padding: 8px 10px; border-bottom: 1px solid color-mix(in srgb, var(--muted) 18%, transparent); vertical-align: top; }
@@ -101,6 +110,20 @@ robots: noindex, nofollow
     .att-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
     .att code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12.5px; }
     .att tr.is-dim td { color: var(--muted); }
+    .att-mobile { display: none; }
+    @media (max-width: 700px) {
+      .att-wrap { display: none; }
+      .att-mobile { display: grid; }
+      .att-mobile__item { border-bottom: 1px solid color-mix(in srgb, var(--muted) 18%, transparent); padding: 10px 2px; }
+      .att-mobile__summary { display: grid; grid-template-columns: minmax(0,1fr) auto 42px; gap: 8px; align-items: center; }
+      .att-mobile__name { min-width: 0; font-weight: 700; overflow-wrap: anywhere; }
+      .att-mobile__meta { color: var(--muted); font-size: 12px; margin-top: 3px; }
+      .att-mobile__qty { white-space: nowrap; font-size: 12.5px; }
+      .att-mobile__toggle { width: 40px; height: 40px; border-radius: 999px; border: 1px solid color-mix(in srgb, var(--muted) 35%, transparent); background: transparent; color: inherit; font: 700 20px/1 inherit; cursor: pointer; }
+      .att-mobile__details { display: grid; grid-template-columns: auto minmax(0,1fr); gap: 7px 12px; margin-top: 10px; padding: 10px; border-radius: 9px; background: color-mix(in srgb, var(--muted) 10%, transparent); font-size: 12.5px; overflow-wrap: anywhere; }
+      .att-mobile__details[hidden] { display: none; }
+      .att-mobile__label { color: var(--muted); }
+    }
   </style>
 </head>
 <body class="book-page">
@@ -120,6 +143,11 @@ robots: noindex, nofollow
         <button class="book-btn" type="button" id="deskRefresh">Refresh</button>
         <button class="book-btn book-btn--ghost" type="button" id="deskForget">Sign out</button>
         <span class="book-muted" style="font-size:13px" id="deskCount"></span>
+      </div>
+      <div class="desk-tabs" role="tablist" aria-label="Event records">
+        <button class="desk-tab" type="button" role="tab" aria-selected="true" data-desk-view="active">Active (0)</button>
+        <button class="desk-tab" type="button" role="tab" aria-selected="false" data-desk-view="past">Past (0)</button>
+        <button class="desk-tab" type="button" role="tab" aria-selected="false" data-desk-view="cancelled">Cancelled (0)</button>
       </div>
       <div class="desk-cards" id="deskCards"></div>
       <p class="book-muted" id="deskEmpty" hidden style="margin-top:18px">

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -22,8 +22,11 @@
     refresh: document.getElementById('deskRefresh'),
     forget: document.getElementById('deskForget')
   };
+  els.tabs = Array.prototype.slice.call(document.querySelectorAll('[data-desk-view]'));
 
   var token = '';
+  var occurrenceGroups = { active: [], past: [], cancelled: [] };
+  var currentView = 'active';
 
   function readToken() {
     try { return localStorage.getItem(STORE_KEY) || ''; } catch (err) { return ''; }
@@ -65,6 +68,19 @@
       }
       if (!res.ok) throw new Error('request failed: ' + res.status);
       return res.json();
+    });
+  }
+
+  function apiPost(path) {
+    return fetch(API + path, {
+      method: 'POST', cache: 'no-store',
+      headers: { Authorization: 'Bearer ' + token }
+    }).then(function (res) {
+      return res.json().catch(function () { return {}; }).then(function (body) {
+        if (res.status === 401) { var auth = new Error('unauthorized'); auth.unauthorized = true; throw auth; }
+        if (!res.ok) { var err = new Error(body.error || 'request_failed'); err.code = body.error; throw err; }
+        return body;
+      });
     });
   }
 
@@ -130,6 +146,38 @@
 
           wrap.appendChild(table);
           container.appendChild(wrap);
+
+          var mobile = el('div', 'att-mobile');
+          live.forEach(function (booking, index) {
+            var item = el('div', 'att-mobile__item');
+            var summary = el('div', 'att-mobile__summary');
+            var identity = el('div');
+            identity.appendChild(el('div', 'att-mobile__name', booking.name || '—'));
+            identity.appendChild(el('div', 'att-mobile__meta', booking.status === 'paid' ? 'Paid' : 'Holding'));
+            summary.appendChild(identity);
+            summary.appendChild(el('div', 'att-mobile__qty', booking.qty + (Number(booking.qty) === 1 ? ' ticket' : ' tickets')));
+
+            var detailId = 'att-detail-' + occurrence.id + '-' + index;
+            var expand = el('button', 'att-mobile__toggle', '+');
+            expand.type = 'button'; expand.setAttribute('aria-expanded', 'false'); expand.setAttribute('aria-controls', detailId);
+            expand.setAttribute('aria-label', 'Show details for ' + (booking.name || 'attendee'));
+            summary.appendChild(expand); item.appendChild(summary);
+
+            var detail = el('div', 'att-mobile__details'); detail.id = detailId; detail.hidden = true;
+            function field(label, value) { detail.appendChild(el('span', 'att-mobile__label', label)); detail.appendChild(el('span', null, value || '—')); }
+            field('Email', booking.email); field('Phone', booking.phone); field('Paid', rupees(booking.amount_paise));
+            field('Status', booking.status); field('Ticket IDs', booking.codes ? String(booking.codes).split(',').join(', ') : '—');
+            if (booking.paid_at) field('Paid at', formatWhen(booking.paid_at));
+            if (booking.razorpay_payment_id) field('Payment ref', booking.razorpay_payment_id);
+            if (booking.notes) field('Notes', booking.notes);
+            expand.addEventListener('click', function () {
+              var opening = detail.hidden; detail.hidden = !opening; expand.textContent = opening ? '−' : '+';
+              expand.setAttribute('aria-expanded', opening ? 'true' : 'false');
+              expand.setAttribute('aria-label', (opening ? 'Hide' : 'Show') + ' details for ' + (booking.name || 'attendee'));
+            });
+            item.appendChild(detail); mobile.appendChild(item);
+          });
+          container.appendChild(mobile);
         }
 
         container.hidden = false;
@@ -148,7 +196,7 @@
       });
   }
 
-  function renderOccurrence(occurrence) {
+  function renderOccurrence(occurrence, view) {
     var card = el('section', 'occ');
 
     var top = el('div', 'occ__top');
@@ -211,10 +259,56 @@
       renderAttendees(occurrence, attendees, toggle);
     });
     actions.appendChild(toggle);
+    if (view === 'active' || view === 'past' || view === 'cancelled') {
+      var menu = document.createElement('details'); menu.className = 'occ__menu';
+      var summary = document.createElement('summary'); summary.setAttribute('aria-label', 'More actions for ' + (occurrence.title || 'event')); summary.textContent = '⋮';
+      var panel = el('div', 'occ__menu-panel');
+      var action = el('button', null, view === 'cancelled' ? 'Remove from dashboard' : (view === 'past' ? 'Mark as cancelled' : 'Cancel event'));
+      action.type = 'button';
+      action.addEventListener('click', function () {
+        menu.open = false;
+        var hiding = view === 'cancelled';
+        var message = hiding
+          ? 'Remove this cancelled event from the dashboard? Its booking records will remain stored. This cannot be undone here.'
+          : 'Mark this event as cancelled? It must already be removed from Google Calendar. Refunds are not automatic.';
+        if (!window.confirm(message)) return;
+        action.disabled = true;
+        apiPost('/api/admin/occurrences/' + encodeURIComponent(occurrence.id) + (hiding ? '/hide' : '/cancel'))
+          .then(function () { load(); })
+          .catch(function (err) {
+            action.disabled = false;
+            if (err.unauthorized) { writeToken(''); token = ''; showGate('Your saved token is no longer valid. Paste it again.'); return; }
+            var text = err.code === 'still_in_calendar'
+              ? 'This event is still present in Google Calendar. Remove it there, wait for the public feed to update, and try again.'
+              : err.code === 'calendar_check_failed'
+                ? 'Google Calendar could not be verified. No changes were made; please try again.'
+                : 'The event could not be updated. Please refresh and try again.';
+            window.alert(text);
+          });
+      });
+      panel.appendChild(action); menu.appendChild(summary); menu.appendChild(panel); actions.appendChild(menu);
+    }
     card.appendChild(actions);
     card.appendChild(attendees);
 
     return card;
+  }
+
+  function renderDashboard() {
+    var list = occurrenceGroups[currentView] || [];
+    els.cards.innerHTML = '';
+    list.forEach(function (occurrence) { els.cards.appendChild(renderOccurrence(occurrence, currentView)); });
+    if (els.empty) { els.empty.hidden = list.length > 0; els.empty.textContent = currentView === 'active'
+      ? 'No active dates.' : currentView === 'past' ? 'No past events.' : 'No cancelled events.'; }
+    els.tabs.forEach(function (tab) {
+      var view = tab.dataset.deskView; var count = (occurrenceGroups[view] || []).length;
+      tab.textContent = view.charAt(0).toUpperCase() + view.slice(1) + ' (' + count + ')';
+      tab.setAttribute('aria-selected', view === currentView ? 'true' : 'false');
+    });
+    if (els.count) {
+      var totalLeft = (occurrenceGroups.active || []).reduce(function (sum, o) { return sum + (Number(o.left) || 0); }, 0);
+      els.count.textContent = (occurrenceGroups.active || []).length + ' active date' + ((occurrenceGroups.active || []).length === 1 ? '' : 's') + ' · ' + totalLeft + ' tickets left';
+    }
   }
 
   /* ------------------------------------------------------------ token gate */
@@ -290,22 +384,12 @@
 
     api('/api/admin/occurrences')
       .then(function (data) {
-        var list = (data && data.occurrences) || [];
+        occurrenceGroups = (data && data.occurrences) || { active: [], past: [], cancelled: [] };
         writeToken(token);
         hideGate();
         if (els.body) els.body.hidden = false;
 
-        els.cards.innerHTML = '';
-        list.forEach(function (occurrence) {
-          els.cards.appendChild(renderOccurrence(occurrence));
-        });
-
-        if (els.empty) els.empty.hidden = list.length > 0;
-        if (els.count) {
-          var totalLeft = list.reduce(function (sum, o) { return sum + (Number(o.left) || 0); }, 0);
-          els.count.textContent = list.length + ' upcoming date' + (list.length === 1 ? '' : 's')
-            + ' · ' + totalLeft + ' tickets left in total';
-        }
+        renderDashboard();
         if (els.stamp) els.stamp.textContent = 'Updated ' + formatWhen(new Date().toISOString());
       })
       .catch(function (err) {
@@ -339,6 +423,7 @@
     window.addEventListener('keydown', trapFocus);
 
     if (els.refresh) els.refresh.addEventListener('click', function () { load(); });
+    els.tabs.forEach(function (tab) { tab.addEventListener('click', function () { currentView = tab.dataset.deskView; renderDashboard(); }); });
     if (els.forget) {
       els.forget.addEventListener('click', function () {
         writeToken('');

--- a/worker/package.json
+++ b/worker/package.json
@@ -9,9 +9,10 @@
     "migrate:remote": "npx wrangler d1 migrations apply gameslab-ticketing --remote",
     "seed:local": "npx wrangler d1 execute gameslab-ticketing --local --file=./seed/events.sql",
     "seed:remote": "npx wrangler d1 execute gameslab-ticketing --remote --file=./seed/events.sql",
-    "test": "npm run test:signature && npm run test:hold",
+    "test": "npm run test:signature && npm run test:hold && npm run test:admin",
     "test:signature": "node test/verify-signature.mjs",
     "test:hold": "python3 test/seat-hold.test.py",
+    "test:admin": "node test/admin-calendar.test.mjs",
     "webhook:sign": "node test/sign-webhook.mjs",
     "tail": "npx wrangler tail",
     "pay:latest": "bash test/pay-latest.sh"

--- a/worker/src/calendar-sync.js
+++ b/worker/src/calendar-sync.js
@@ -56,6 +56,39 @@ export const VENUES = [
   { name: 'Bagelstein',          map_url: 'https://maps.app.goo.gl/5sPfiUZsgoZFxo73A' },
 ];
 
+/**
+ * Cancellation is a dashboard archive operation, never the source of truth for
+ * scheduling. Prove the exact occurrence is absent from the complete current
+ * Calendar feed before allowing it. No date filtering is applied here.
+ */
+export async function occurrenceIsInCalendar(env, occurrence) {
+  const res = await fetch(env.CALENDAR_ICS_URL);
+  if (!res.ok) throw new Error(`ICS fetch failed (${res.status})`);
+
+  const icsText = await res.text();
+  if (!/BEGIN:VCALENDAR/i.test(icsText) || !/END:VCALENDAR/i.test(icsText)) {
+    throw new Error('ICS response was not a calendar');
+  }
+  const entries = parseIcs(icsText);
+  const timezone = occurrence.timezone || env.TIMEZONE || 'Asia/Kolkata';
+  const occurrenceDay = dayKeyInZone(new Date(occurrence.starts_at_utc), timezone);
+  const uid = String(occurrence.gcal_uid || '').trim();
+
+  return entries.some((entry) => {
+    const sameDay = dayKeyInZone(entry.start, timezone) === occurrenceDay;
+    // Recurring Calendar instances can share a UID, so the local date is part
+    // of the identity even for the preferred UID match.
+    if (uid && entry.uid && entry.uid === uid) return sameDay;
+    if (uid) return false;
+    const candidate = slugify(entry.summary);
+    const slugMatches = candidate === occurrence.event_slug
+      || candidate.startsWith(occurrence.event_slug)
+      || candidate.endsWith(occurrence.event_slug)
+      || candidate.includes(occurrence.event_slug);
+    return slugMatches && sameDay;
+  });
+}
+
 export async function syncCalendar(env) {
   const timezone = env.TIMEZONE || 'Asia/Kolkata';
   const res = await fetch(env.CALENDAR_ICS_URL);

--- a/worker/src/db.js
+++ b/worker/src/db.js
@@ -60,12 +60,47 @@ export async function listOccurrencesForStaff(db, now) {
               o.capacity - (${COMMITTED_SEATS}) AS available
          FROM occurrences o
          JOIN events e ON e.slug = o.event_slug
-        WHERE o.starts_at_utc >= ?1
+        WHERE o.status != 'hidden'
         ORDER BY o.starts_at_utc ASC`,
     )
     .bind(now)
     .all();
   return results || [];
+}
+
+export async function getOccurrenceForStaff(db, occurrenceId, now) {
+  return await db
+    .prepare(
+      `SELECT o.id, o.event_slug, o.starts_at_utc, o.timezone, o.venue_name,
+              o.venue_map_url, o.capacity, o.price_paise, o.status, o.gcal_uid,
+              e.title AS event_title,
+              COALESCE((SELECT SUM(b.qty) FROM bookings b
+                         WHERE b.occurrence_id = o.id AND b.status = 'paid'), 0) AS sold,
+              COALESCE((SELECT SUM(b.amount_paise) FROM bookings b
+                         WHERE b.occurrence_id = o.id AND b.status = 'paid'), 0) AS revenue_paise,
+              o.capacity - (${COMMITTED_SEATS}) AS available
+         FROM occurrences o
+         JOIN events e ON e.slug = o.event_slug
+        WHERE o.id = ?2`,
+    )
+    .bind(now, occurrenceId)
+    .first();
+}
+
+export async function cancelOccurrence(db, occurrenceId) {
+  const result = await db.prepare(
+    `UPDATE occurrences SET status = 'cancelled'
+      WHERE id = ?1 AND status NOT IN ('cancelled', 'hidden')`,
+  ).bind(occurrenceId).run();
+  return Boolean(result.meta && result.meta.changes === 1);
+}
+
+export async function hideOccurrence(db, occurrenceId) {
+  const result = await db.prepare(
+    `UPDATE occurrences SET status = 'hidden'
+      WHERE id = ?1 AND status = 'cancelled'`,
+  ).bind(occurrenceId).run();
+  return Boolean(result.meta && result.meta.changes === 1);
 }
 
 export async function createHold(db, {

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,7 +1,7 @@
 import * as db from './db.js';
 import { createOrder, verifyWebhookSignature, verifyPaymentSignature } from './razorpay.js';
 import { bookingId, accessToken } from './ids.js';
-import { syncCalendar } from './calendar-sync.js';
+import { syncCalendar, occurrenceIsInCalendar } from './calendar-sync.js';
 import { sendTicketEmail } from './email.js';
 import { qrSvg, qrPng } from './qr.js';
 
@@ -29,6 +29,14 @@ function json(env, request, body, status = 200, extraHeaders = {}) {
 
 function nowIso() {
   return new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+function localDayKey(value, timezone) {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    year: 'numeric', month: '2-digit', day: '2-digit', timeZone: timezone,
+  }).formatToParts(new Date(value));
+  const get = (type) => parts.find((part) => part.type === type)?.value || '';
+  return `${get('year')}-${get('month')}-${get('day')}`;
 }
 
 function isStaff(env, request) {
@@ -443,25 +451,59 @@ async function handleStaffOccurrences(env, request) {
 
   const rows = await db.listOccurrencesForStaff(env.DB, nowIso());
 
+  const occurrences = rows.map((row) => ({
+    id: row.id,
+    event_slug: row.event_slug,
+    title: row.event_title,
+    starts_at: row.starts_at_utc,
+    timezone: row.timezone,
+    venue_name: row.venue_name,
+    capacity: Number(row.capacity) || 0,
+    price_paise: Number(row.price_paise) || 0,
+    sold: Number(row.sold) || 0,
+    held: Number(row.held) || 0,
+    left: Math.max(0, Number(row.available) || 0),
+    revenue_paise: Number(row.revenue_paise) || 0,
+    status: row.status,
+    on_sale: row.status === 'open' && row.price_paise > 0 && Number(row.available) > 0,
+  }));
+
+  const timezone = env.TIMEZONE || 'Asia/Kolkata';
+  const today = localDayKey(new Date(), timezone);
+
   return json(env, request, {
     generated_at: nowIso(),
-    occurrences: rows.map((row) => ({
-      id: row.id,
-      event_slug: row.event_slug,
-      title: row.event_title,
-      starts_at: row.starts_at_utc,
-      timezone: row.timezone,
-      venue_name: row.venue_name,
-      capacity: Number(row.capacity) || 0,
-      price_paise: Number(row.price_paise) || 0,
-      sold: Number(row.sold) || 0,
-      held: Number(row.held) || 0,
-      left: Math.max(0, Number(row.available) || 0),
-      revenue_paise: Number(row.revenue_paise) || 0,
-      status: row.status,
-      on_sale: row.status === 'open' && row.price_paise > 0 && Number(row.available) > 0,
-    })),
+    occurrences: {
+      active: occurrences.filter((o) => o.status !== 'cancelled' && localDayKey(o.starts_at, timezone) >= today),
+      past: occurrences.filter((o) => o.status !== 'cancelled' && localDayKey(o.starts_at, timezone) < today).reverse(),
+      cancelled: occurrences.filter((o) => o.status === 'cancelled').reverse(),
+    },
   }, 200, { 'Cache-Control': 'no-store' });
+}
+
+async function handleCancelOccurrence(env, request, occurrenceId) {
+  if (!isStaff(env, request)) return json(env, request, { error: 'unauthorized' }, 401);
+  const occurrence = await db.getOccurrenceForStaff(env.DB, occurrenceId, nowIso());
+  if (!occurrence || occurrence.status === 'hidden') return json(env, request, { error: 'not_found' }, 404);
+  if (occurrence.status === 'cancelled') return json(env, request, { error: 'already_cancelled' }, 409);
+
+  let stillScheduled;
+  try {
+    stillScheduled = await occurrenceIsInCalendar(env, occurrence);
+  } catch (err) {
+    console.error('calendar cancellation check failed', occurrenceId, err.message);
+    return json(env, request, { error: 'calendar_check_failed' }, 503);
+  }
+  if (stillScheduled) return json(env, request, { error: 'still_in_calendar' }, 409);
+
+  const changed = await db.cancelOccurrence(env.DB, occurrenceId);
+  return json(env, request, { ok: changed }, changed ? 200 : 409);
+}
+
+async function handleHideOccurrence(env, request, occurrenceId) {
+  if (!isStaff(env, request)) return json(env, request, { error: 'unauthorized' }, 401);
+  const changed = await db.hideOccurrence(env.DB, occurrenceId);
+  return json(env, request, changed ? { ok: true } : { error: 'not_cancelled' }, changed ? 200 : 409);
 }
 
 async function handleAttendees(env, request, url) {
@@ -550,6 +592,16 @@ export default {
 
       if (pathname === '/api/admin/attendees' && request.method === 'GET') {
         return await handleAttendees(env, request, url);
+      }
+
+      const cancelMatch = pathname.match(/^\/api\/admin\/occurrences\/([a-z0-9-]{3,80})\/cancel$/);
+      if (cancelMatch && request.method === 'POST') {
+        return await handleCancelOccurrence(env, request, cancelMatch[1]);
+      }
+
+      const hideMatch = pathname.match(/^\/api\/admin\/occurrences\/([a-z0-9-]{3,80})\/hide$/);
+      if (hideMatch && request.method === 'POST') {
+        return await handleHideOccurrence(env, request, hideMatch[1]);
       }
 
       if (pathname === '/api/admin/sync' && request.method === 'POST') {

--- a/worker/test/admin-calendar.test.mjs
+++ b/worker/test/admin-calendar.test.mjs
@@ -1,0 +1,96 @@
+import { occurrenceIsInCalendar } from '../src/calendar-sync.js';
+
+const originalFetch = globalThis.fetch;
+const failures = [];
+
+function check(label, got, want) {
+  const ok = got === want;
+  console.log(`${ok ? '  PASS  ' : '  FAIL  '}${label}: got ${JSON.stringify(got)}, want ${JSON.stringify(want)}`);
+  if (!ok) failures.push(label);
+}
+
+function calendar(events) {
+  return `BEGIN:VCALENDAR\r\n${events.join('\r\n')}\r\nEND:VCALENDAR\r\n`;
+}
+
+function vevent({ uid, summary, start, status = '' }) {
+  return [
+    'BEGIN:VEVENT',
+    `UID:${uid}`,
+    `SUMMARY:${summary}`,
+    `DTSTART;TZID=Asia/Kolkata:${start}`,
+    status ? `STATUS:${status}` : '',
+    'END:VEVENT',
+  ].filter(Boolean).join('\r\n');
+}
+
+async function withFeed(body, status, fn) {
+  globalThis.fetch = async () => new Response(body, { status });
+  return await fn();
+}
+
+const env = { CALENDAR_ICS_URL: 'https://calendar.invalid/feed.ics', TIMEZONE: 'Asia/Kolkata' };
+const occurrence = {
+  event_slug: 'board-game-night',
+  starts_at_utc: '2026-08-14T14:00:00Z',
+  timezone: 'Asia/Kolkata',
+  gcal_uid: 'calendar-uid-1',
+};
+
+console.log('admin cancellation calendar evidence\n');
+
+await withFeed(calendar([
+  vevent({ uid: 'old-event', summary: 'Old Event', start: '20250101T190000' }),
+  vevent({ uid: 'calendar-uid-1', summary: 'Renamed Event', start: '20260814T193000' }),
+]), 200, async () => {
+  check('searches the complete feed and matches by UID', await occurrenceIsInCalendar(env, occurrence), true);
+});
+
+await withFeed(calendar([
+  vevent({ uid: 'calendar-uid-1', summary: 'Board Game Night', start: '20260821T193000' }),
+]), 200, async () => {
+  check('does not confuse another recurrence sharing the UID', await occurrenceIsInCalendar(env, occurrence), false);
+});
+
+await withFeed(calendar([
+  vevent({ uid: 'different-uid', summary: 'Board Game Night', start: '20260814T193000' }),
+]), 200, async () => {
+  check('does not fall back to title when a stored UID exists', await occurrenceIsInCalendar(env, occurrence), false);
+});
+
+await withFeed(calendar([
+  vevent({ uid: 'fallback-uid', summary: 'Board Game Night', start: '20260814T193000' }),
+]), 200, async () => {
+  check('falls back to slug and local date for legacy rows', await occurrenceIsInCalendar(env, { ...occurrence, gcal_uid: null }), true);
+});
+
+await withFeed(calendar([
+  vevent({ uid: 'calendar-uid-1', summary: 'Board Game Night', start: '20260814T193000', status: 'CANCELLED' }),
+]), 200, async () => {
+  check('treats an explicitly cancelled calendar entry as absent', await occurrenceIsInCalendar(env, occurrence), false);
+});
+
+let fetchFailed = false;
+try {
+  await withFeed('unavailable', 503, () => occurrenceIsInCalendar(env, occurrence));
+} catch (err) {
+  fetchFailed = /ICS fetch failed/.test(err.message);
+}
+check('fails closed when the calendar cannot be fetched', fetchFailed, true);
+
+let malformedFailed = false;
+try {
+  await withFeed('<html>not a calendar</html>', 200, () => occurrenceIsInCalendar(env, occurrence));
+} catch (err) {
+  malformedFailed = /not a calendar/.test(err.message);
+}
+check('fails closed for a malformed calendar response', malformedFailed, true);
+
+globalThis.fetch = originalFetch;
+
+if (failures.length) {
+  console.error(`\n${failures.length} check(s) failed`);
+  process.exitCode = 1;
+} else {
+  console.log('\nall checks passed');
+}


### PR DESCRIPTION
### Motivation

- Prevent staff from cancelling an occurrence while it still exists in the public Google Calendar feed by verifying calendar evidence before changing status.  
- Improve the staff dashboard UX with tabbed views (active/past/cancelled) and inline actions for cancelling or hiding occurrences.  
- Expose a clearer mobile CTA for events with no upcoming date while avoiding it blocking content during downward scroll.  

### Description

- Add calendar verification helper `occurrenceIsInCalendar` and wire it into two new admin endpoints `POST /api/admin/occurrences/:id/cancel` and `POST /api/admin/occurrences/:id/hide` with server handlers `handleCancelOccurrence` and `handleHideOccurrence`.  
- Add DB helpers `getOccurrenceForStaff`, `cancelOccurrence`, and `hideOccurrence`, and change `handleStaffOccurrences` to return grouped occurrences `{ active, past, cancelled }`.  
- Extend the worker HTTP router to expose the cancel/hide endpoints and import the calendar check; add `localDayKey` for day-based grouping.  
- Frontend admin UX: add tabbed dashboard UI and client-side grouping in `assets/js/admin.js`, include `apiPost` helper, mobile-friendly attendee list (`att-mobile`), and per-occurrence action menu that calls the new admin endpoints.  
- Event page UX: move/add the "no date yet" CTA into the hero area and add a mobile FAB `fabNoDate`; update `scripts-event-core.html` to manage `fabNoDate` visibility and scrolling behavior and adjust FAB spacing; update styles in `styles-event.html` for `.fab-no-date`.  
- Remove duplicated `no-date` block from `_includes/event-sections.html` and tidy related markup in `_includes/event-hero.html`.  
- Add `worker/test/admin-calendar.test.mjs` unit tests and update `worker/package.json` to include `test:admin` in the `test` script.  

### Testing

- Ran worker test suite with `npm run test` in `worker`, which now runs `test:signature`, `test:hold`, and `test:admin`, and all checks passed.  
- Executed the new calendar evidence test `node worker/test/admin-calendar.test.mjs` which validated UID/date matching and failure modes and passed.  
- No UI regression tests were added; manual inspection was used for the new admin UI and event FAB behavior during the rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c6cfbeaa8832ca5962a1fd4878911)