### PR TITLE
Remove multi-date “Happening on … more date(s)” text from desktop event card

### DIFF
--- a/_includes/event-hero.html
+++ b/_includes/event-hero.html
@@ -33,7 +33,6 @@
                 </div>
                 <a id="scAddCal" class="inline-link" href="#" download="games-lab-event.ics">Add to Calendar</a>
               </div>
-              <p class="sched-more-dates" id="scMoreDates" hidden></p>
               <div class="schedule-row">
                 <div class="where"><span id="scWhere">—</span></div>
                 <a id="scDir" class="inline-link" href="#" target="_blank" rel="noopener">Get directions</a>

--- a/_includes/scripts-event-core.html
+++ b/_includes/scripts-event-core.html
@@ -273,10 +273,6 @@
       if (fabBook){ fabBook.setAttribute('hidden',''); }
       updateFabSpacing();
     }
-    if (scMoreDates && matches.length > 1){
-      scMoreDates.textContent = 'Happening on ' + (matches.length - 1) + ' more date' + (matches.length === 2 ? '' : 's');
-      scMoreDates.removeAttribute('hidden');
-    }
   } else {
     scHeading && scHeading.setAttribute('hidden','');
     if (scBlock) scBlock.hidden = true;


### PR DESCRIPTION
### Motivation
- The right-side event card displayed a redundant summary line like “Happening on 1 more date” on desktop that duplicates the date selector and adds visual clutter.
- The intent is to simplify the desktop schedule card while preserving date selection and booking behavior.

### Description
- Removed the DOM placeholder paragraph for multi-date copy by deleting the `<p class="sched-more-dates" id="scMoreDates" hidden></p>` element in `/_includes/event-hero.html`.
- Removed the JavaScript that populated and revealed the multi-date message in `/_includes/scripts-event-core.html` while leaving date selection, schedule display, ticket links, and no-date fallbacks intact.
- Change is applied to shared event includes so it affects all event pages using the site’s event layout.

### Testing
- Ran `git diff --check` to validate whitespace and simple issues, which completed without errors.
- Built the site with `bundle exec jekyll build`, which completed successfully and generated `_site` output.
- Verified the phrase is no longer produced by searching with `rg -n -i "happening on [0-9]+ more dates?|scMoreDates|sched-more-dates"`, which returned no matches in the includes/layouts/events output.
- Attempted `npx playwright install chromium` to capture a browser screenshot for visual verification but the Playwright browser download failed due to an external CDN `403` and thus automated browser-based screenshotting could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80bfae0cfc832cbcd242332da46fb6)