### PR TITLE
Improve schedule UI: time separator, more-dates label, and select alignment

### DIFF
--- a/_includes/scripts-event-core.html
+++ b/_includes/scripts-event-core.html
@@ -119,6 +119,7 @@
   const scSeats   = document.getElementById('scSeats');
   const scPrice   = document.getElementById('scPrice');
   const scBook    = document.getElementById('scBook');
+  const scMoreDates = document.getElementById('scMoreDates');
   const fabBook   = document.getElementById('fabBook');
   const fabNoDate = document.getElementById('fabNoDate');
   const shareFab  = document.getElementById('shareFab');
@@ -251,7 +252,7 @@
     if (scBlock) scBlock.hidden = false;
     scWhen && (scWhen.textContent = whenText);
     scWhere && (scWhere.textContent = locationText || '');
-    scTime && (scTime.textContent = timeStr ? ' · ' + timeStr : '');
+    scTime && (scTime.textContent = timeStr ? ' | ' + timeStr : '');
     if (scAdd) scAdd.href = makeICS({ title: titleFallback, start: scheduleDate, endTime:match?.end, durationHours:3, locationText, locationUrl, description:location.href });
     if (scDir){
       if (locationUrl){
@@ -274,7 +275,7 @@
       updateFabSpacing();
     }
     if (scMoreDates && matches.length > 1){
-      scMoreDates.textContent = 'Happening on ' + (matches.length - 1) + ' more date' + (matches.length === 2 ? '' : 's');
+      scMoreDates.textContent = 'and on ' + (matches.length - 1) + ' more date' + (matches.length === 2 ? '' : 's');
       scMoreDates.removeAttribute('hidden');
     }
   } else {
@@ -615,7 +616,7 @@
         const venue = item.venue_name || entry.location_name || 'To be Announced';
         if (scWhen) scWhen.textContent = dateOnlyLabel(choice);
         if (scWhere) scWhere.textContent = venue;
-        if (scTime) scTime.textContent = fmtTime(start, timezone) ? ' · ' + fmtTime(start, timezone) : '';
+        if (scTime) scTime.textContent = fmtTime(start, timezone) ? ' | ' + fmtTime(start, timezone) : '';
         if (scAdd) scAdd.href = makeICS({ title:titleFallback, start, endTime:entry.end, durationHours:3, locationText:venue, locationUrl:mapUrl, description:location.href });
         if (scDir){
           if (mapUrl){ scDir.href = mapUrl; scDir.removeAttribute('hidden'); }

--- a/_includes/styles-event.html
+++ b/_includes/styles-event.html
@@ -128,7 +128,7 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
   .schedule-list{display:grid;gap:10px;margin-bottom:10px}
   .schedule-row{display:flex;align-items:baseline;justify-content:space-between;gap:10px}
   .when{font-weight:900;font-size:16px;min-width:0;flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-  .schedule-date-select{width:auto;max-width:175px;padding:0 24px 0 0;border:0;border-radius:0;background-color:var(--card);color:var(--text-main);font:inherit;font-size:14px;font-weight:900;cursor:pointer;box-shadow:none}
+  .schedule-date-select{width:auto;max-width:175px;padding:0 24px 0 0;border:0;border-radius:0;background-color:var(--card);color:var(--text-main);font:inherit;font-size:14px;font-weight:900;text-align:left;text-align-last:left;cursor:pointer;box-shadow:none}
   .schedule-date-select:hover,.schedule-date-select:focus{background-color:var(--card);box-shadow:none}
   .schedule-date-select:focus-visible{outline:0}
   .schedule-date-select[hidden]{display:none}


### PR DESCRIPTION
### Motivation
- Improve readability and consistency of the event schedule UI by adjusting the time separator, making the "more dates" indicator available, and ensuring the date-select control text aligns correctly.

### Description
- Reference the `scMoreDates` element and update the more-dates label to use the phrasing `and on X more date(s)` when multiple occurrences exist.
- Change the schedule time separator from `' · '` to `' | '` in both the initial rendering and the schedule choice renderer (`scTime` updates).
- Add `text-align:left` and `text-align-last:left` to `.schedule-date-select` in `styles-event.html` to force left-aligned select text.

### Testing
- Ran `npm run lint` and `npm run build` locally and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80bfae0cfc832cbcd242332da46fb6)