### PR TITLE
Adjust schedule UI: time separators, “more dates” copy, and date-select styling

### DIFF
--- a/_includes/cards-upcoming.html
+++ b/_includes/cards-upcoming.html
@@ -176,7 +176,7 @@
       if (entry.additional_dates > 0){
         const moreDates = document.createElement('p');
         moreDates.className = 'more-dates';
-        moreDates.textContent = 'Happening on ' + entry.additional_dates + ' more date' + (entry.additional_dates === 1 ? '' : 's');
+        moreDates.textContent = 'and on ' + entry.additional_dates + ' more date' + (entry.additional_dates === 1 ? '' : 's');
         body.appendChild(moreDates);
       }
 

--- a/_includes/scripts-event-core.html
+++ b/_includes/scripts-event-core.html
@@ -119,6 +119,7 @@
   const scSeats   = document.getElementById('scSeats');
   const scPrice   = document.getElementById('scPrice');
   const scBook    = document.getElementById('scBook');
+  const scMoreDates = document.getElementById('scMoreDates');
   const fabBook   = document.getElementById('fabBook');
   const fabNoDate = document.getElementById('fabNoDate');
   const shareFab  = document.getElementById('shareFab');
@@ -251,7 +252,7 @@
     if (scBlock) scBlock.hidden = false;
     scWhen && (scWhen.textContent = whenText);
     scWhere && (scWhere.textContent = locationText || '');
-    scTime && (scTime.textContent = timeStr ? ' · ' + timeStr : '');
+    scTime && (scTime.textContent = timeStr ? ' | ' + timeStr : '');
     if (scAdd) scAdd.href = makeICS({ title: titleFallback, start: scheduleDate, endTime:match?.end, durationHours:3, locationText, locationUrl, description:location.href });
     if (scDir){
       if (locationUrl){
@@ -274,7 +275,7 @@
       updateFabSpacing();
     }
     if (scMoreDates && matches.length > 1){
-      scMoreDates.textContent = 'Happening on ' + (matches.length - 1) + ' more date' + (matches.length === 2 ? '' : 's');
+      scMoreDates.textContent = 'and on ' + (matches.length - 1) + ' more date' + (matches.length === 2 ? '' : 's');
       scMoreDates.removeAttribute('hidden');
     }
   } else {
@@ -615,7 +616,7 @@
         const venue = item.venue_name || entry.location_name || 'To be Announced';
         if (scWhen) scWhen.textContent = dateOnlyLabel(choice);
         if (scWhere) scWhere.textContent = venue;
-        if (scTime) scTime.textContent = fmtTime(start, timezone) ? ' · ' + fmtTime(start, timezone) : '';
+        if (scTime) scTime.textContent = fmtTime(start, timezone) ? ' | ' + fmtTime(start, timezone) : '';
         if (scAdd) scAdd.href = makeICS({ title:titleFallback, start, endTime:entry.end, durationHours:3, locationText:venue, locationUrl:mapUrl, description:location.href });
         if (scDir){
           if (mapUrl){ scDir.href = mapUrl; scDir.removeAttribute('hidden'); }

--- a/_includes/styles-event.html
+++ b/_includes/styles-event.html
@@ -128,7 +128,7 @@ body{background:var(--bg);color:var(--text-main);font-family:'Comfortaa',cursive
   .schedule-list{display:grid;gap:10px;margin-bottom:10px}
   .schedule-row{display:flex;align-items:baseline;justify-content:space-between;gap:10px}
   .when{font-weight:900;font-size:16px;min-width:0;flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-  .schedule-date-select{width:auto;max-width:175px;padding:0 24px 0 0;border:0;border-radius:0;background-color:var(--card);color:var(--text-main);font:inherit;font-size:14px;font-weight:900;cursor:pointer;box-shadow:none}
+  .schedule-date-select{display:inline-block;width:175px;max-width:100%;margin:0;padding:0 24px 0 0;border:0;border-radius:0;-webkit-appearance:none;appearance:none;background-color:var(--card);background-image:linear-gradient(45deg,transparent 50%,currentColor 50%),linear-gradient(135deg,currentColor 50%,transparent 50%);background-position:calc(100% - 8px) 50%,calc(100% - 3px) 50%;background-size:5px 5px,5px 5px;background-repeat:no-repeat;color:var(--text-main);font:inherit;font-size:14px;font-weight:900;text-align:left;text-align-last:left;direction:ltr;cursor:pointer;box-shadow:none}
   .schedule-date-select:hover,.schedule-date-select:focus{background-color:var(--card);box-shadow:none}
   .schedule-date-select:focus-visible{outline:0}
   .schedule-date-select[hidden]{display:none}


### PR DESCRIPTION
### Motivation
- Improve consistency and clarity of schedule displays by standardizing the time separator and the copy for multi-date events.
- Make the desktop schedule date dropdown visually consistent and remove native browser appearance to show a custom arrow.

### Description
- Replaced the middle-dot time separator `·` with a pipe `|` in schedule displays by updating `scTime` assignments and `renderScheduleChoice` formatting in `scripts-event-core.html`.
- Changed the multi-date messaging from `Happening on X more date(s)` to `and on X more date(s)` in both the upcoming cards template (`_includes/cards-upcoming.html`) and the schedule drawer logic (`_includes/scripts-event-core.html`), and added `scMoreDates` DOM lookup to show/hide that element.
- Restyled the desktop date selector by updating `.schedule-date-select` in `_includes/styles-event.html` to use `display:inline-block`, fixed `width`, removed native appearance, and added a custom arrow via `background-image` and positioning.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80bfae0cfc832cbcd242332da46fb6)